### PR TITLE
[Misc] Warn when loop_config(name=) decorates a nested for-loop

### DIFF
--- a/quadrants/ir/frontend_ir.cpp
+++ b/quadrants/ir/frontend_ir.cpp
@@ -1472,7 +1472,33 @@ void ASTBuilder::create_assert_stmt(const Expr &cond,
   this->insert(std::move(stmt_unique));
 }
 
+void ASTBuilder::warn_if_named_nested_loop() {
+  if (for_loop_dec_.config.loop_name.empty()) {
+    return;
+  }
+  // Walk the open block stack; if any enclosing block belongs to a for-loop, the loop we are about
+  // to emit is nested and its name will not survive offloading. `while` (incl. graph_do_while) and
+  // `if` are FrontendWhileStmt / FrontendIfStmt, not FrontendForStmt, so they are correctly ignored;
+  // `qd.checkpoint` pushes no block at all.
+  bool nested = false;
+  for (int i = (int)stack_.size() - 1; i >= 0; i--) {
+    Stmt *parent = stack_[i]->parent_stmt();
+    if (parent && parent->is<FrontendForStmt>()) {
+      nested = true;
+      break;
+    }
+  }
+  QD_WARN_IF(nested,
+             "qd.loop_config(name=\"{}\") is set on a for-loop nested inside another for-loop; the "
+             "name is ignored. Only top-level loops (direct children of the kernel body, a "
+             "qd.checkpoint, or a qd.graph_do_while) are offloaded as separately named GPU kernels. "
+             "Move the loop to the top level, or unroll the enclosing loop with "
+             "`for ... in qd.static(range(...))` so each inner loop becomes its own named kernel.",
+             for_loop_dec_.config.loop_name);
+}
+
 void ASTBuilder::begin_frontend_range_for(const Expr &i, const Expr &s, const Expr &e, const DebugInfo &dbg_info) {
+  warn_if_named_nested_loop();
   for_loop_dec_.config.stream_parallel_group_id = current_stream_parallel_group_id_;
   auto stmt_unique = std::make_unique<FrontendForStmt>(i, s, e, arch_, for_loop_dec_.config, dbg_info);
   auto stmt = stmt_unique.get();
@@ -1484,6 +1510,7 @@ void ASTBuilder::begin_frontend_range_for(const Expr &i, const Expr &s, const Ex
 void ASTBuilder::begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars,
                                                     SNode *snode,
                                                     const DebugInfo &dbg_info) {
+  warn_if_named_nested_loop();
   QD_WARN_IF(for_loop_dec_.config.strictly_serialized,
              "ti.loop_config(serialize=True) does not have effect on the struct for. "
              "The execution order is not guaranteed.");
@@ -1498,6 +1525,7 @@ void ASTBuilder::begin_frontend_struct_for_on_snode(const ExprGroup &loop_vars,
 void ASTBuilder::begin_frontend_struct_for_on_external_tensor(const ExprGroup &loop_vars,
                                                               const Expr &external_tensor,
                                                               const DebugInfo &dbg_info) {
+  warn_if_named_nested_loop();
   QD_WARN_IF(for_loop_dec_.config.strictly_serialized,
              "ti.loop_config(serialize=True) does not have effect on the struct for. "
              "The execution order is not guaranteed.");
@@ -1514,6 +1542,7 @@ void ASTBuilder::begin_frontend_mesh_for(const Expr &i,
                                          const mesh::MeshPtr &mesh_ptr,
                                          const mesh::MeshElementType &element_type,
                                          const DebugInfo &dbg_info) {
+  warn_if_named_nested_loop();
   QD_WARN_IF(for_loop_dec_.config.strictly_serialized,
              "ti.loop_config(serialize=True) does not have effect on the mesh for. "
              "The execution order is not guaranteed.");

--- a/quadrants/ir/frontend_ir.h
+++ b/quadrants/ir/frontend_ir.h
@@ -1023,6 +1023,12 @@ class ASTBuilder {
   void create_scope(std::unique_ptr<Block> &list, LoopType tp = NotLoop);
   void pop_scope();
 
+  // Warn if `qd.loop_config(name=...)` is set on a for-loop that is lexically nested inside another
+  // for-loop. Only top-level loops become separately offloaded (and therefore separately named) GPU
+  // kernels, so a name on a nested loop is silently dropped. `qd.checkpoint` and `qd.graph_do_while`
+  // do NOT count as nesting here (they keep their inner loops top-level / offloaded).
+  void warn_if_named_nested_loop();
+
   void bit_vectorize() {
     for_loop_dec_.config.is_bit_vectorized = true;
   }

--- a/tests/python/test_loop_config_name.py
+++ b/tests/python/test_loop_config_name.py
@@ -84,6 +84,54 @@ def test_loop_config_name_serialize_ir_dump(tmp_path: pathlib.Path, monkeypatch:
     assert combined.count("loop_name=serial_sum") == 1
 
 
+@test_utils.test(offline_cache=False)
+def test_loop_config_name_nested_loop_warns(capfd: pytest.CaptureFixture[str]):
+    # A `name` on a loop nested inside another for-loop is silently dropped (only top-level loops
+    # become separately named kernels), so quadrants should warn about it.
+    n = 16
+    a = qd.ndarray(qd.i32, shape=(n,))
+
+    @qd.kernel
+    def nested(a: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        for _ in range(2):
+            qd.loop_config(name="nested_inner")
+            for i in range(n):
+                a[i] = a[i] + 1
+
+    capfd.readouterr()
+    nested(a)
+    qd.sync()
+
+    combined = "".join(capfd.readouterr())
+    assert "nested_inner" in combined, combined
+    assert "nested inside another for-loop" in combined, combined
+
+
+@test_utils.test(offline_cache=False)
+def test_loop_config_name_top_level_does_not_warn(capfd: pytest.CaptureFixture[str]):
+    # Names on top-level loops and on loops unrolled via `qd.static` are honored, so they must NOT
+    # trigger the nested-loop warning.
+    n = 16
+    a = qd.ndarray(qd.i32, shape=(n,))
+
+    @qd.kernel
+    def top_and_static(a: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        qd.loop_config(name="top_loop")
+        for i in range(n):
+            a[i] = a[i] + 1
+        for _ in qd.static(range(2)):
+            qd.loop_config(name="static_loop")
+            for i in range(n):
+                a[i] = a[i] + 1
+
+    capfd.readouterr()
+    top_and_static(a)
+    qd.sync()
+
+    combined = "".join(capfd.readouterr())
+    assert "nested inside another for-loop" not in combined, combined
+
+
 @test_utils.test(arch=[qd.cuda], offline_cache=False)
 def test_loop_config_name_cuda_ptx_dump(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("QD_DUMP_IR", "1")


### PR DESCRIPTION
qd.loop_config(name=...) only takes effect on top-level loops, which are
the ones promoted to separately offloaded (and named) GPU kernels. When a
named loop is lexically nested inside another for-loop it stays serial
inside the parent's offloaded task, so its name is silently dropped (the
kernel shows up as the generic kernelN_M). This bit the qipc line-search
loops before they were switched to qd.static unrolling.

Emit a warning at trace time when a named for/struct-for/mesh-for is
nested inside another for-loop. while (incl. qd.graph_do_while), if, and
qd.checkpoint are not treated as nesting, since those keep their inner
loops top-level/offloaded. The check is a small walk of the open block
stack at AST-build time and does not change generated IR/codegen.Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
