### PR TITLE
[Type] Canonicalize default_fp/ip to the registered primitive singleton

### DIFF
--- a/python/quadrants/lang/impl.py
+++ b/python/quadrants/lang/impl.py
@@ -478,12 +478,17 @@ class PyQuadrants:
 
     def set_default_fp(self, fp):
         assert fp in [f16, f32, f64]
-        self.default_fp = fp
+        # qd.init() deep-copies the default_fp arg (misc.py), yielding a DataType that is == but not identical to
+        # the registered primitive singleton -- its id is then absent from primitive_types.type_ids, which silently
+        # breaks id-based type recognition for anything that resolves a dtype via get_runtime().default_fp (e.g. the
+        # simt tile proxies). Re-bind to the canonical singleton so identity is preserved.
+        self.default_fp = {f16: f16, f32: f32, f64: f64}[fp]
         default_cfg().default_fp = self.default_fp
 
     def set_default_ip(self, ip):
         assert ip in [i32, i64]
-        self.default_ip = ip
+        # See set_default_fp: canonicalize to the registered singleton so id-based type checks keep working.
+        self.default_ip = {i32: i32, i64: i64}[ip]
         self.default_up = u32 if ip == i32 else u64
         default_cfg().default_ip = self.default_ip
         default_cfg().default_up = self.default_up

--- a/tests/python/test_types.py
+++ b/tests/python/test_types.py
@@ -2,6 +2,7 @@ import pytest
 
 import quadrants as qd
 from quadrants.lang import impl
+from quadrants.types import primitive_types
 
 from tests import test_utils
 
@@ -163,3 +164,53 @@ def test_uint_max(dt, val):
     fs = f.to_numpy()
     for f in fs:
         assert f == val
+
+
+@test_utils.test(default_fp=qd.f32)
+def test_default_fp_canonical_identity():
+    """Regression: get_runtime().default_fp must stay identity-equal to the registered primitive singleton.
+
+    qd.init(default_fp=qd.f32) deep-copies the dtype (misc.py), so without canonicalization in set_default_fp the
+    stored default_fp is == qd.f32 (same hash) but has an id outside primitive_types.type_ids.  That silently breaks
+    id-based type recognition for any code that resolves a dtype via get_runtime().default_fp and then uses it as a
+    type -- e.g. an in-kernel type construction or a kernel/func annotation (this is what broke the simt tile
+    proxies).
+    """
+    dfp = impl.get_runtime().default_fp
+    assert dfp == qd.f32
+    assert id(dfp) in primitive_types.type_ids
+
+    @qd.kernel
+    def use_as_call() -> qd.f32:
+        return dfp(2.5)  # type construction; falls through to a raw call (and raises) if id not registered
+
+    assert use_as_call() == pytest.approx(2.5)
+
+    @qd.kernel
+    def use_as_annotation(x: dfp) -> dfp:  # annotation must be recognized as a primitive type
+        return x * 2.0
+
+    assert use_as_annotation(3.0) == pytest.approx(6.0)
+
+
+@test_utils.test(default_ip=qd.i32)
+def test_default_ip_canonical_identity():
+    """Regression: get_runtime().default_ip must stay identity-equal to the registered primitive singleton.
+
+    Same root cause as test_default_fp_canonical_identity, for the default integer type.
+    """
+    dip = impl.get_runtime().default_ip
+    assert dip == qd.i32
+    assert id(dip) in primitive_types.type_ids
+
+    @qd.kernel
+    def use_as_call() -> qd.i32:
+        return dip(7)
+
+    assert use_as_call() == 7
+
+    @qd.kernel
+    def use_as_annotation(x: dip) -> dip:
+        return x * 2
+
+    assert use_as_annotation(5) == 10


### PR DESCRIPTION
qd.init(default_fp=...) deep-copies the dtype arg (misc.py), so get_runtime().default_fp was == qd.f32 but a distinct object whose id is absent from primitive_types.type_ids. Type recognition across the AST transformer is id-based (id(x) in type_ids), so any code that resolves a dtype via get_runtime().default_fp and uses it as a type -- an in-kernel type construction (dtype(0.0)) or a kernel/func annotation -- silently broke with "Quadrants data types cannot be called outside Quadrants kernels" / "Invalid type annotation". This surfaced as an xdist-order-dependent flake in the simt tile proxies.

set_default_fp/set_default_ip now re-bind the (equal-valued) input back to the canonical registered singleton so identity is preserved. The stored value is unchanged, so value-based consumers are unaffected; only the broken id-based checks are restored. Verified on CPU: the default_fp object is now usable as an in-kernel call and as a kernel/func annotation.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
