### PR TITLE
[Build] Use cached Windows clang download

### DIFF
--- a/.github/workflows/scripts/ti_build/alter.py
+++ b/.github/workflows/scripts/ti_build/alter.py
@@ -12,7 +12,7 @@ import psutil
 # -- own --
 from . import misc
 from .cmake import cmake_args
-from .compiler import get_cache_home
+from .misc import get_cache_home
 from .tinysh import Command
 
 

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -15,7 +15,7 @@ from pathlib import Path
 # -- own --
 from .cmake import cmake_args
 from .dep import download_dep
-from .misc import banner, error, get_cache_home, warn
+from .misc import banner, error, warn
 from .tinysh import powershell
 
 
@@ -49,19 +49,13 @@ def setup_clang(as_compiler=True) -> None:
         clang = join(brew_prefix, "opt", "llvm@22", "bin", "clang")
         clangpp = join(brew_prefix, "opt", "llvm@22", "bin", "clang++")
     elif (u.system, u.machine) == ("Windows", "AMD64"):
-        # Keep llvm_version / build_version in sync with setup_llvm() in llvm.py.
-        # The build_version is part of the cache dir name so a rebuilt or bumped archive lands in a
-        # fresh directory; this lets download_dep's own cache check skip re-extraction on every run
-        # (previously forced via force=True, which re-extracted ~1GB on every build.py invocation).
-        llvm_version = "22.1.0"
-        build_version = "202603120808"
-        out = get_cache_home() / f"clang-{llvm_version}-{build_version}"
-        url = (
-            "https://github.com/Genesis-Embodied-AI/quadrants-sdk-builds/releases/download/"
-            f"llvm-{llvm_version}-{build_version}/taichi-llvm-{llvm_version}-windows-amd64.zip"
-        )
-        download_dep(url, out)
-        clang = str(out / "bin" / "clang++.exe").replace("\\", "\\\\")
+        # The clang++ we need on Windows ships inside the same LLVM toolchain archive that
+        # setup_llvm() downloads, so reuse that extracted copy rather than fetching/unpacking a
+        # second identical zip. This also keeps the LLVM version + build_version defined only in
+        # llvm.py instead of being duplicated here.
+        from .llvm import setup_llvm
+
+        clang = str(Path(setup_llvm()) / "bin" / "clang++.exe").replace("\\", "\\\\")
         clangpp = clang
     else:
         raise RuntimeError(f"Unsupported platform: {u.system} {u.machine}")

--- a/.github/workflows/scripts/ti_build/compiler.py
+++ b/.github/workflows/scripts/ti_build/compiler.py
@@ -49,9 +49,18 @@ def setup_clang(as_compiler=True) -> None:
         clang = join(brew_prefix, "opt", "llvm@22", "bin", "clang")
         clangpp = join(brew_prefix, "opt", "llvm@22", "bin", "clang++")
     elif (u.system, u.machine) == ("Windows", "AMD64"):
-        out = get_cache_home() / "clang-22-1-0"
-        url = "https://github.com/Genesis-Embodied-AI/quadrants-sdk-builds/releases/download/llvm-22.1.0-202603120808/taichi-llvm-22.1.0-windows-amd64.zip"
-        download_dep(url, out, force=True)
+        # Keep llvm_version / build_version in sync with setup_llvm() in llvm.py.
+        # The build_version is part of the cache dir name so a rebuilt or bumped archive lands in a
+        # fresh directory; this lets download_dep's own cache check skip re-extraction on every run
+        # (previously forced via force=True, which re-extracted ~1GB on every build.py invocation).
+        llvm_version = "22.1.0"
+        build_version = "202603120808"
+        out = get_cache_home() / f"clang-{llvm_version}-{build_version}"
+        url = (
+            "https://github.com/Genesis-Embodied-AI/quadrants-sdk-builds/releases/download/"
+            f"llvm-{llvm_version}-{build_version}/taichi-llvm-{llvm_version}-windows-amd64.zip"
+        )
+        download_dep(url, out)
         clang = str(out / "bin" / "clang++.exe").replace("\\", "\\\\")
         clangpp = clang
     else:


### PR DESCRIPTION
setup_clang() on Windows was the only download_dep() caller passing force=True, which unconditionally deleted and re-extracted the ~1GB LLVM/clang archive on every build.py invocation (and could trigger a full re-download when the cached zip's size check failed). Drop force=True and fold build_version into the cache dir name, matching setup_llvm() in llvm.py: download_dep's own cache check now skips re-extraction, while a rebuilt or version-bumped archive still lands in a fresh directory.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
