### PR TITLE
[Build] Build wheel against pybind11 3.0.4

### DIFF
--- a/.github/workflows/scripts/ti_build/entry.py
+++ b/.github/workflows/scripts/ti_build/entry.py
@@ -43,10 +43,6 @@ def build_wheel(python: Command) -> None:
     # Build via scikit-build-core. Use `pip wheel` (not `python -m build`) because the repo ships a top-level build.py
     # that would shadow the `build` module under `-m`. --no-build-isolation: the LLVM/clang toolchain is not
     # pip-installable (it is provisioned by setup_basic_build_env above), so build deps come from this env.
-    # Perf test: --no-build-isolation means the env's pybind11 is what gets compiled into the bindings, so pin the
-    # exact version here. pybind11 3.0.x has a faster Python<->C++ call dispatch than 2.x; the prior implicit 2.x in
-    # this build path cost ~8% on call-overhead-bound CPU benchmarks (batch_size=0).
-    python("-m", "pip", "install", "pybind11==3.0.4")
     with nice():
         python("-m", "pip", "wheel", "--no-deps", "--no-build-isolation", "-w", "dist", ".")
 

--- a/.github/workflows/scripts/ti_build/entry.py
+++ b/.github/workflows/scripts/ti_build/entry.py
@@ -43,6 +43,10 @@ def build_wheel(python: Command) -> None:
     # Build via scikit-build-core. Use `pip wheel` (not `python -m build`) because the repo ships a top-level build.py
     # that would shadow the `build` module under `-m`. --no-build-isolation: the LLVM/clang toolchain is not
     # pip-installable (it is provisioned by setup_basic_build_env above), so build deps come from this env.
+    # Perf test: --no-build-isolation means the env's pybind11 is what gets compiled into the bindings, so pin the
+    # exact version here. pybind11 3.0.x has a faster Python<->C++ call dispatch than 2.x; the prior implicit 2.x in
+    # this build path cost ~8% on call-overhead-bound CPU benchmarks (batch_size=0).
+    python("-m", "pip", "install", "pybind11==3.0.4")
     with nice():
         python("-m", "pip", "wheel", "--no-deps", "--no-build-isolation", "-w", "dist", ".")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,6 @@ endif()
 
 # No support of Python for any case quadrants is integrated
 # in another project as submodule.
-set(PYBIND11_VERSION "2.13.6" CACHE STRING "Pybind11 version to use")
 option(QD_WITH_PYTHON "Build with Python language binding" ON)
 if (QD_WITH_PYTHON)
     include(cmake/PythonNumpyPybind11.cmake)

--- a/cmake/PythonNumpyPybind11.cmake
+++ b/cmake/PythonNumpyPybind11.cmake
@@ -14,7 +14,5 @@ message("    numpy include: ${NUMPY_INCLUDE_DIR}")
 
 include_directories(${NUMPY_INCLUDE_DIR})
 
-include(FetchContent)
-
 message("Using pybind11 version: ${pybind11_version}")
 find_package(pybind11 CONFIG REQUIRED)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ Homepage = "https://github.com/Genesis-Embodied-AI/quadrants"
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    "pybind11<3.0.0",      # pybind11 bindings (headers + CMake config)
+    "pybind11==3.0.4",     # pybind11 bindings (headers + CMake config); 3.0.x = faster call dispatch (perf test)
     "pybind11-stubgen",    # consumed by the CMake stub-generation install hook
     "numpy>=2.0.0",        # NumPy headers for the extension
     "setuptools_scm>=6.0", # version from git tags (metadata provider below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,11 +51,11 @@ dev = [
     "colorama",
     "coverage",
     "Pillow",
-    # pybind11 should be less than 3.0.0 for now
-    # pybind11 3.0.0 caused builds to start failing.
-    # whilst we could probably get 3.0.0 working too, I feel that x.0.0 releases, in opensource (and closed source
-    # too often) might not always be very stable, so we might want to wait 3-6 months before trying it?)
-    "pybind11<3.0.0",
+    # pybind11 >=3.0 has a faster Python<->C++ call dispatch (~8% on call-overhead-bound CPU benchmarks). This
+    # dev/test group provides the pybind11 that gets compiled into the wheel for --no-build-isolation builds (the
+    # production/CI path), so it must stay in sync with [build-system].requires below. Stub generation works with
+    # current pybind11-stubgen (>=2.5, which supports the 3.x ABI).
+    "pybind11>=3.0.0",
     "pybind11-stubgen",
     "pydantic",
     "GitPython",
@@ -109,7 +109,7 @@ Homepage = "https://github.com/Genesis-Embodied-AI/quadrants"
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    "pybind11==3.0.4",     # pybind11 bindings (headers + CMake config); 3.0.x = faster call dispatch (perf test)
+    "pybind11>=3.0.0",     # pybind11 bindings (headers + CMake config); 3.0.x = faster Python<->C++ call dispatch
     "pybind11-stubgen",    # consumed by the CMake stub-generation install hook
     "numpy>=2.0.0",        # NumPy headers for the extension
     "setuptools_scm>=6.0", # version from git tags (metadata provider below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     # dev/test group provides the pybind11 that gets compiled into the wheel for --no-build-isolation builds (the
     # production/CI path), so it must stay in sync with [build-system].requires below. Stub generation works with
     # current pybind11-stubgen (>=2.5, which supports the 3.x ABI).
-    "pybind11>=3.0.0",
+    "pybind11>=3.0.0,<4.0.0",
     "pybind11-stubgen",
     "pydantic",
     "GitPython",
@@ -109,7 +109,7 @@ Homepage = "https://github.com/Genesis-Embodied-AI/quadrants"
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    "pybind11>=3.0.0",     # pybind11 bindings (headers + CMake config); 3.0.x = faster Python<->C++ call dispatch
+    "pybind11>=3.0.0,<4.0.0",  # pybind11 bindings (headers + CMake config); 3.0.x = faster Python<->C++ call dispatch
     "pybind11-stubgen",    # consumed by the CMake stub-generation install hook
     "numpy>=2.0.0",        # NumPy headers for the extension
     "setuptools_scm>=6.0", # version from git tags (metadata provider below)


### PR DESCRIPTION
The skbuild-core build path (pip wheel --no-build-isolation) compiled the pybind11 bindings against pybind11 2.x, whereas the previous classic build happened to use 3.0.x. pybind11 3.0 has a faster Python<->C++ call dispatch, worth ~8% on call-overhead-bound CPU benchmarks (anymal_zero, batch_size=0; CUDA at batch 30000 is unaffected).

Pin the build-system requirement to pybind11==3.0.4 and, because the wheel is built with --no-build-isolation, also install it explicitly in build_wheel so the env actually compiles against 3.0.4. For branch perf testing.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
