### PR TITLE
[AMDGPU] Fix cross-half shuffle select for top-half lanes on wave64

### DIFF
--- a/quadrants/runtime/llvm/runtime_module/runtime.cpp
+++ b/quadrants/runtime/llvm/runtime_module/runtime.cpp
@@ -1096,7 +1096,6 @@ i32 amdgpu_cross_half_shuffle_i32(i32 target_lane, i32 value) {
   // cross-SIMD case via the ``swapped`` payload. On CDNA the wave is one SIMD64 so both reads return the same value
   // and the select is a no-op; we don't try to optimize that out because the dead read is cheap (LLVM CSE may fold
   // it anyway).
-  i32 self_lane = amdgpu_lane_id();
   i32 swapped = amdgpu_permlane64(value);
   i32 byte = (target_lane & 31) * 4;
   // ``llvm.amdgcn.ds.bpermute`` is the real hardware ``ds_bpermute_b32`` -- but if LLVM's uniformity analysis decides
@@ -1122,9 +1121,16 @@ i32 amdgpu_cross_half_shuffle_i32(i32 target_lane, i32 value) {
 #if defined(ARCH_amdgpu) && (defined(__x86_64__) || defined(__i386__) || defined(__amdgcn__))
   __asm__ volatile("" : "+v"(byte));
 #endif
+  // ``byte`` masks the lane index to 5 bits, so ``from_self_half`` always reads the low SIMD32
+  // (lanes 0..31) and ``from_other_half`` (via the ``permlane64`` swap) always reads the high SIMD32
+  // (lanes 32..63) -- regardless of which half the executing lane sits in. The correct payload is
+  // therefore selected purely by which half the *target* lane lives in (``target_lane & 32``); it must
+  // not depend on the executing lane. The previous ``(target_lane ^ self_lane) & 32`` was wrong for
+  // top-half lanes: for a same-half target it wrongly picked the other-half read, so e.g.
+  // ``shuffle_up`` on lanes 32..63 returned lane ``target_lane - 32`` instead of ``target_lane``.
   i32 from_self_half = amdgpu_ds_bpermute(byte, value);
   i32 from_other_half = amdgpu_ds_bpermute(byte, swapped);
-  return ((target_lane ^ self_lane) & 32) ? from_other_half : from_self_half;
+  return (target_lane & 32) ? from_other_half : from_self_half;
 }
 
 i32 amdgpu_shuffle_i32(i32 index, i32 value) {


### PR DESCRIPTION

## Summary

On wave64 AMD GPUs, every cross-half subgroup shuffle (`subgroup.shuffle`, `shuffle_up`, `shuffle_down`) returns the wrong value on the upper half of the wave (lanes 32..63). `amdgpu_cross_half_shuffle_i32` picks between the two `ds_bpermute` reads with a *self-relative* condition, but the reads are *absolute*, so the select is inverted for the top-half lanes.

The most visible consequence is that `subgroup.inclusive_*_tiled` / `exclusive_*_tiled` (Hillis-Steele scans, built on `shuffle_up`) miscompile from lane 32 onward on a full wave64. `reduce_*_tiled` / `shuffle_down` happen to only consume the low-half result, so they escape — which is why this went unnoticed.

One-line fix: select on the target lane's half only.

## Root cause

`amdgpu_cross_half_shuffle_i32` issues two reads and selects per lane:

```cpp
i32 self_lane = amdgpu_lane_id();
i32 swapped   = amdgpu_permlane64(value);
i32 byte      = (target_lane & 31) * 4;           // 5-bit ds_bpermute address
...
i32 from_self_half  = amdgpu_ds_bpermute(byte, value);
i32 from_other_half = amdgpu_ds_bpermute(byte, swapped);
return ((target_lane ^ self_lane) & 32) ? from_other_half : from_self_half;   // bug
```

Because `byte` masks the lane index to 5 bits, on wave64 the reads are **absolute, not lane-relative**:

- `from_self_half` always resolves to the low SIMD32 (lanes 0..31),
- `from_other_half` (via the `permlane64` swap) always resolves to the high SIMD32 (lanes 32..63),

regardless of which half the *executing* lane sits in. The correct payload therefore depends only on which half the **target** lane lives in — `target_lane & 32` — and must not depend on the executing lane.

The old `(target_lane ^ self_lane) & 32` is correct for the bottom half (`self_lane & 32 == 0`) but inverts the choice for the top half: for a same-half target it picks the *other*-half read. Concretely, identity `shuffle(v, i)` returns `value[i & 31]` on lanes 32..63 (e.g. lane 40 reads lane 8), and `shuffle_up` on the upper half returns lane `target_lane - 32` instead of `target_lane`.

## Fix

```cpp
-  i32 self_lane = amdgpu_lane_id();
   i32 swapped = amdgpu_permlane64(value);
   ...
-  return ((target_lane ^ self_lane) & 32) ? from_other_half : from_self_half;
+  return (target_lane & 32) ? from_other_half : from_self_half;
```

`self_lane` becomes unused and is removed.

## Testing

Built the runtime bitcode from source and validated with standalone quadrants kernels (no Genesis), single wave64, `log2_size=6`.

**R9700 (gfx1201 / RDNA4)** — the affected path:

| test | before | after |
|---|---|---|
| identity `shuffle(v, i)` | lanes 32..63 wrong (`value[i&31]`) | 0 wrong lanes |
| `inclusive_add_tiled(6)` | miscompiles from lane 32 | PASS |
| `exclusive_add_tiled(6)` | miscompiles from lane 32 | PASS |
| `reduce_add_tiled(6)` | PASS (unaffected) | PASS |

**MI300 (gfx942 / CDNA3)** — not affected, no regression: on CDNA the `ds_bpermute` lane mask is the full 64 and `permlane64` is patched to identity, so `from_self_half == from_other_half` and the select is a no-op. Identity / scan / reduce PASS both before and after this change.

## Notes / scope

- The fix relies on `ds_bpermute` addressing absolute lanes 0..31 for the masked low-31 address on wave64 — confirmed on gfx1201 (RDNA4). If any older RDNA part (gfx10.x) is genuinely SIMD32-*relative* here, it would need a separate path; I don't have that hardware to check and have flagged it rather than assumed it.
- This is a correctness fix and is independent of PR #746 (which fixes the CDNA `permlane64` codegen crash via a per-arch `ds_bpermute` lane mask). #746 leaves this RDNA half-select bug in place; the two changes are complementary.
