### PR TITLE
[AMDGPU] Fix: apply amdgpu-ieee/amdgpu-dx10-clamp to all functions

### DIFF
--- a/quadrants/runtime/amdgpu/jit_amdgpu.cpp
+++ b/quadrants/runtime/amdgpu/jit_amdgpu.cpp
@@ -31,25 +31,20 @@ std::string JITSessionAMDGPU::compile_module_to_hsaco(std::unique_ptr<llvm::Modu
     function_pass_manager_addrcast.run(*func);
   function_pass_manager_addrcast.doFinalization();
 
-  // Apply amdgpu-ieee and amdgpu-dx10-clamp to ALL functions, not just
-  // AMDGPU_KERNEL entries. LLVM's inliner refuses to inline a callee into a
-  // caller when they carry mismatching target-specific attributes, so setting
-  // these on kernels only prevents internal runtime device functions (e.g.
-  // gpu_parallel_range_for and the body functions it dispatches) from being
-  // inlined into the kernel entry. Without that inlining, InferAddressSpaces
-  // cannot see the full pointer chain from kernel params to field data and
-  // cannot promote flat_load/flat_store/flat_atomic to global_*, which causes
-  // flat-atomic coherency issues and a throughput regression on gfx942
-  // (MI300X). Applying them uniformly keeps every function's attribute set
-  // consistent so inlining and address-space inference run as intended. The
-  // hasFnAttribute guard keeps each write idempotent.
+  // Give every function the same amdgpu-ieee / amdgpu-dx10-clamp mode attributes. LLVM's inliner refuses to inline a
+  // callee whose target-mode attributes differ from the caller, so a kernel-only setting would leave the runtime device
+  // functions (gpu_parallel_range_for and the body functions it dispatches) un-inlined; without that inlining
+  // InferAddressSpaces cannot follow the pointer chain from kernel params to field data and cannot promote
+  // flat_load/flat_store/flat_atomic to global_*, costing a ~4% throughput regression on gfx942 (MI300X). Uniformity is
+  // what restores inlining, not the specific value, so honor strict math: amdgpu-ieee stays at the IEEE-compliant
+  // default (true) unless fast_math is requested. We overwrite unconditionally (rather than guarding on hasFnAttribute)
+  // so a value preset on a linked ROCm device-lib function cannot re-introduce the mismatch.
+  const char *ieee_mode = this->config_.fast_math ? "false" : "true";
   for (auto &F : *llvm_module) {
-    if (!F.hasFnAttribute("amdgpu-ieee")) {
-      F.addFnAttr("amdgpu-ieee", "false");
-    }
-    if (!F.hasFnAttribute("amdgpu-dx10-clamp")) {
-      F.addFnAttr("amdgpu-dx10-clamp", "false");
-    }
+    if (F.isDeclaration())
+      continue;
+    F.addFnAttr("amdgpu-ieee", ieee_mode);
+    F.addFnAttr("amdgpu-dx10-clamp", "false");
   }
 
   if (llvm::verifyModule(*llvm_module, &llvm::errs())) {

--- a/quadrants/runtime/amdgpu/jit_amdgpu.cpp
+++ b/quadrants/runtime/amdgpu/jit_amdgpu.cpp
@@ -31,6 +31,27 @@ std::string JITSessionAMDGPU::compile_module_to_hsaco(std::unique_ptr<llvm::Modu
     function_pass_manager_addrcast.run(*func);
   function_pass_manager_addrcast.doFinalization();
 
+  // Apply amdgpu-ieee and amdgpu-dx10-clamp to ALL functions, not just
+  // AMDGPU_KERNEL entries. LLVM's inliner refuses to inline a callee into a
+  // caller when they carry mismatching target-specific attributes, so setting
+  // these on kernels only prevents internal runtime device functions (e.g.
+  // gpu_parallel_range_for and the body functions it dispatches) from being
+  // inlined into the kernel entry. Without that inlining, InferAddressSpaces
+  // cannot see the full pointer chain from kernel params to field data and
+  // cannot promote flat_load/flat_store/flat_atomic to global_*, which causes
+  // flat-atomic coherency issues and a throughput regression on gfx942
+  // (MI300X). Applying them uniformly keeps every function's attribute set
+  // consistent so inlining and address-space inference run as intended. The
+  // hasFnAttribute guard keeps each write idempotent.
+  for (auto &F : *llvm_module) {
+    if (!F.hasFnAttribute("amdgpu-ieee")) {
+      F.addFnAttr("amdgpu-ieee", "false");
+    }
+    if (!F.hasFnAttribute("amdgpu-dx10-clamp")) {
+      F.addFnAttr("amdgpu-dx10-clamp", "false");
+    }
+  }
+
   if (llvm::verifyModule(*llvm_module, &llvm::errs())) {
     llvm_module->print(llvm::errs(), nullptr);
     QD_WARN("Module broken");


### PR DESCRIPTION
## Summary

Backend-only AMDGPU codegen change. No public API, no new user-tunable knobs, solver-agnostic. Self-contained; does not depend on #774.

Sets `amdgpu-ieee` and `amdgpu-dx10-clamp` uniformly on **all** functions (not just `AMDGPU_KERNEL` entries). LLVM's inliner refuses to inline a callee into a caller when the two carry **different values** for these mode attributes; if only kernels carry them, internal device functions (e.g. `gpu_parallel_range_for` and the body functions it dispatches) fail to inline, and `InferAddressSpaces` can no longer follow the pointer chain from kernel params to field data to promote `flat_load`/`flat_store`/`flat_atomic` to `global_*`.

## Perf context (please read — the ~4% is not against `main`)

This change was ported from our AMD integration branch, where these attributes were previously set **kernel-only**. Against *that* kernel-only baseline, moving them to all functions removed the caller/callee mismatch and recovered **~4% throughput (301k → 314k)**.

Upstream `main` sets **neither** attribute anywhere, so there is no mismatch to fix on `main` and no perf delta to show. I verified this on gfx942 (MI308X, ROCm 7.2.4, LLVM 22.1.0): builds with and without this change produce **byte-identical AMDGCN and identical throughput** (saxpy ~1159 GB/s, atomic reduction ~126 GB/s, both directions). I also confirmed the mechanism at the IR level with the pinned LLVM 22.1.0 `opt` — the inliner blocks **only** on a present-vs-present *value* mismatch; uniform (either value), absent/absent, and absent/present all inline.

So on `main` this PR is best understood as a **consistency + correctness** change, not a standalone perf win:
- It guarantees these mode attributes can never be asymmetric, so the mismatch-induced regression cannot appear if kernel-only mode attributes are ever introduced.
- Per review, it now **preserves strict IEEE semantics**: `amdgpu-ieee` follows `fast_math` (stays at the IEEE-compliant default `true` unless `fast_math` is requested).

Full mechanism write-up and A/B data are in the follow-up comment below.

## Change

Single file (`quadrants/runtime/amdgpu/jit_amdgpu.cpp`): a small loop over every non-declaration function setting both attributes uniformly. `amdgpu-ieee` is gated on `fast_math` (IEEE-compliant `true` by default, `false` only under `fast_math`); `amdgpu-dx10-clamp=false` (the normal compute value). Attributes are written unconditionally (no `hasFnAttribute` guard) so a value preset on a linked ROCm device-lib function cannot re-introduce the mismatch. ~13 lines, no other files touched.

## Independence from #774

An earlier version of this fix was stacked on #774 and reused its per-kernel `fn_attrs` registry. That coupling has been removed — this PR applies against `main` directly and can merge with or without #774.
