### PR TITLE
[Nanobind] Silence interpreter-shutdown leak warnings

### DIFF
--- a/cmake/QuadrantsCore.cmake
+++ b/cmake/QuadrantsCore.cmake
@@ -336,7 +336,10 @@ if(QD_WITH_PYTHON)
     # NOMINSIZE: keep the project optimization level (-O3) for the binding layer instead of nanobind's
     # default -Os, matching the previous pybind11 NO_EXTRAS build and avoiding per-call overhead in the
     # hot launch path. NB_STATIC links the nanobind core statically (single extension module).
-    nanobind_add_module(${CORE_WITH_PYBIND_LIBRARY_NAME} NB_STATIC NOMINSIZE ${QUADRANTS_PYBIND_SOURCE})
+    # NB_DOMAIN: isolate our nb_internals (type registry + the leak-warning flag) from any other
+    # nanobind extension sharing the process. Without it we build in the default domain, so our
+    # nb::set_leak_warnings(false) would also silence unrelated default-domain extensions' diagnostics.
+    nanobind_add_module(${CORE_WITH_PYBIND_LIBRARY_NAME} NB_DOMAIN quadrants NB_STATIC NOMINSIZE ${QUADRANTS_PYBIND_SOURCE})
 
     # Remove symbols from static libs: https://stackoverflow.com/a/14863432/12003165
     if (LINUX)

--- a/quadrants/python/export.cpp
+++ b/quadrants/python/export.cpp
@@ -12,6 +12,12 @@ namespace quadrants {
 NB_MODULE(quadrants_python, m) {
   m.doc() = "quadrants_python";
 
+  // Disable nanobind's interpreter-shutdown leak checker. It reports the primitive DataType_* module
+  // attributes (registered via the PER_TYPE X-macro in export_lang.cpp) plus the class/method objects
+  // they keep alive as "leaks". These are long-lived module-global singletons, not a growing leak, so
+  // the warnings are pure noise for downstream users (e.g. Genesis) at process exit.
+  nb::set_leak_warnings(false);
+
   register_py_exception_translator();
 
   for (auto &kv : InterfaceHolder::get_instance()->methods) {


### PR DESCRIPTION
nanobind's shutdown leak checker reports the primitive DataType_* module attributes (registered via the PER_TYPE X-macro in export_lang.cpp), along with the DataTypeCxx/Type class objects and their bound methods they keep alive, as leaked instances/types/functions. These are long-lived module-global singletons rather than a growing leak (RSS is flat across tens of thousands of churn iterations), so the messages are pure noise for downstream users such as Genesis at process exit. Disable them via nb::set_leak_warnings(false) in NB_MODULE.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
