### PR TITLE
[CI] Render PR change report in job summary instead of a standalone check

### DIFF
--- a/.github/workflows/pr_change_report.yml
+++ b/.github/workflows/pr_change_report.yml
@@ -12,7 +12,6 @@ concurrency:
 permissions:
   contents: read
   pull-requests: write
-  checks: write
 jobs:
   pr-change-report:
     name: PR change report
@@ -196,44 +195,28 @@ jobs:
             /tmp/pr_change_report/touched_ranges.txt
             /tmp/pr_change_report/function_ranges.jsonl
 
-      - name: Publish PR change report Check
-        if: steps.inputs.outputs.skip != 'true' && github.event_name == 'pull_request'
-        id: publish_check
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const fs = require('fs');
-            let body = fs.readFileSync('/tmp/pr_change_report/report_check.md', 'utf8');
-            const MAX_TEXT = 65000;
-            let truncated = false;
-            if (body.length > MAX_TEXT) {
-              body = body.substring(0, MAX_TEXT) +
-                '\n\n---\n*Report truncated. Download the full report from the workflow artifacts.*';
-              truncated = true;
-            }
-            const summary = truncated
-              ? 'Per-file totals + per-function breakdown (truncated — see artifacts for full report).'
-              : 'Per-file totals + per-function breakdown of code-line additions and removals.';
-            const check = await github.rest.checks.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              head_sha: context.payload.pull_request.head.sha,
-              name: 'PR change report',
-              status: 'completed',
-              conclusion: 'success',
-              output: {
-                title: 'PR change report',
-                summary: summary,
-                text: body,
-              },
-            });
-            core.setOutput('check-url', check.data.html_url);
+      # Render the report into this job's step summary rather than a standalone check run created
+      # via checks.create({head_sha}). A check run made that way cannot be bound to this workflow's
+      # check suite, so GitHub buckets it under an arbitrary workflow (it showed up as e.g.
+      # "Check non-ASCII characters / PR change report"). The step summary lives on this run's
+      # page, so it is always attributed to the "PR change report" workflow.
+      - name: Write report to job summary
+        if: steps.inputs.outputs.skip != 'true'
+        run: |
+          # Job summaries allow up to 1 MiB; cap well under that and fall back to the uploaded
+          # artifact for the (rare) oversized report.
+          MAX_BYTES=900000
+          if [ "$(wc -c < /tmp/pr_change_report/report_check.md)" -gt "$MAX_BYTES" ]; then
+            head -c "$MAX_BYTES" /tmp/pr_change_report/report_check.md >> "$GITHUB_STEP_SUMMARY"
+            printf '\n\n---\n*Report truncated. Download the full report from the workflow artifacts.*\n' \
+              >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat /tmp/pr_change_report/report_check.md >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Post PR comment
         if: steps.inputs.outputs.skip != 'true' && github.event_name == 'pull_request'
         uses: actions/github-script@v8
-        env:
-          REPORT_URL: ${{ steps.publish_check.outputs.check-url }}
         with:
           script: |
             const fs = require('fs');
@@ -244,8 +227,10 @@ jobs:
             const totalRemoved = summary.reduce((acc, s) => acc + s.removed, 0);
             const text = `Total: ${numFiles} file(s) changed, ` +
               `+${totalAdded} -${totalRemoved} code lines.`;
-            const url = process.env.REPORT_URL;
-            const body = url ? `[${text}](${url})` : text;
+            // Link to this run's summary page, which hosts the full per-file / per-function report.
+            const url = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}` +
+              `/actions/runs/${context.runId}`;
+            const body = `[${text}](${url})`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/docs/source/user_guide/contributing.md
+++ b/docs/source/user_guide/contributing.md
@@ -181,9 +181,9 @@ The agent reports up to 10 violations. This check is delayed by 30 minutes, to a
 
 ### PR change report (`pr_change_report.yml`)
 
-Posts a fresh PR comment on every push. The comment is a single line: the totals (file count, code lines added, code lines removed) formatted as a markdown link to a GitHub Check whose page contains the full per-file / per-function breakdown. "Code lines" exclude blank lines, comment-only lines, and (in Python) lines whose only token content is a string literal (i.e. docstrings and continuation lines of multi-line strings). C/C++ `/* … */` block comments are stripped before counting.
+Posts a fresh PR comment on every push. The comment is a single line: the totals (file count, code lines added, code lines removed) formatted as a markdown link to the workflow run summary page, which contains the full per-file / per-function breakdown. "Code lines" exclude blank lines, comment-only lines, and (in Python) lines whose only token content is a string literal (i.e. docstrings and continuation lines of multi-line strings). C/C++ `/* ... */` block comments are stripped before counting.
 
-The number columns on the Check page (without a `+` or `-` sign) are code-line counts in the BASE (pre-PR) version: file size before this PR (0 for newly-added files), function body size before this PR (0 for new functions; original body size for deleted functions). `+<n>` / `-<n>` are code lines added / removed by this PR.
+The number columns in the report (without a `+` or `-` sign) are code-line counts in the BASE (pre-PR) version: file size before this PR (0 for newly-added files), function body size before this PR (0 for new functions; original body size for deleted functions). `+<n>` / `-<n>` are code lines added / removed by this PR.
 
 Files are sorted by added lines descending. Within each file, functions are split into a `New:` group (added by this PR), an `Existing:` group (modified by this PR), and a `Deleted:` group (removed by this PR), and within each group sorted by added lines descending, then removed lines descending. Files that are deleted in their entirety appear as a single per-file row (so the totals stay accurate) but skip the per-function breakdown. Sample shape:
 


### PR DESCRIPTION
A check run created via checks.create({head_sha}) cannot be bound to this workflow's check suite, so GitHub grouped the "PR change report" check under an arbitrary workflow (e.g. "Check non-ASCII characters / PR change report") and produced a duplicate entry. Write the full report to the job step summary instead, and link the PR comment to the run summary page, so it is always attributed to the PR change report workflow. Drop the now-unused checks:write permission.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
