### PR TITLE
[CI] Fix non-ASCII scanner treating "+++" added lines as file headers

### DIFF
--- a/python/tools/check_non_ascii.py
+++ b/python/tools/check_non_ascii.py
@@ -24,9 +24,10 @@ import sys
 import unicodedata
 from dataclasses import dataclass
 
-# Matches a unified-diff hunk header, capturing the starting line number in the new file, e.g.
-# "@@ -12,7 +34,9 @@ optional section heading" -> captures "34".
-_HUNK_RE = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@")
+# Matches a unified-diff hunk header. Captures the old-side line count (group 1, absent -> 1), the
+# new-file start line (group 2), and the new-side line count (group 3, absent -> 1), e.g.
+# "@@ -12,7 +34,9 @@ optional section heading" -> ("7", "34", "9").
+_HUNK_RE = re.compile(r"^@@ -\d+(?:,(\d+))? \+(\d+)(?:,(\d+))? @@")
 
 
 @dataclass
@@ -58,30 +59,38 @@ def _strip_diff_prefix(target: str) -> str | None:
 
 
 def find_violations(diff_text: str) -> list[Violation]:
-    """Parse a unified diff and return non-ASCII violations on added lines, in file order."""
+    """Parse a unified diff and return non-ASCII violations on added lines, in file order.
+
+    ``+++ `` / ``--- `` are recognized as file headers ONLY outside a hunk body. Inside a hunk, an
+    added line whose content starts with ``++ `` is emitted by git as ``+++ ...`` (and a removed
+    line starting with ``-- `` as ``--- ...``); treating those as file headers would skip the line
+    (letting its non-ASCII characters through) and corrupt the tracked path and line numbers. Hunk
+    boundaries are tracked via the line counts declared in the ``@@`` header, so content lines are
+    always classified by their diff marker rather than mistaken for headers.
+    """
     violations: list[Violation] = []
     path: str | None = None
     new_lineno = 0
+    # Old-file / new-file lines still expected in the current hunk body. Both <= 0 means we are
+    # between hunks, i.e. in file-header territory.
+    remaining_old = 0
+    remaining_new = 0
 
     for raw in diff_text.splitlines():
-        if raw.startswith("+++ "):
-            path = _strip_diff_prefix(raw[4:])
-            continue
-        if raw.startswith("--- "):
-            continue
-
-        hunk = _HUNK_RE.match(raw)
-        if hunk:
-            new_lineno = int(hunk.group(1))
-            continue
-
-        if not raw:
-            # A truly empty diff line represents an added/context blank line; treat as context so
-            # line numbering stays aligned. (git emits " " for context blanks, but be defensive.)
-            new_lineno += 1
+        if remaining_old <= 0 and remaining_new <= 0:
+            hunk = _HUNK_RE.match(raw)
+            if hunk:
+                remaining_old = int(hunk.group(1)) if hunk.group(1) else 1
+                new_lineno = int(hunk.group(2))
+                remaining_new = int(hunk.group(3)) if hunk.group(3) else 1
+                continue
+            if raw.startswith("+++ "):
+                path = _strip_diff_prefix(raw[4:])
+            # Any other line here (diff --git, index, "--- " header, mode lines, ...) is ignored.
             continue
 
-        marker = raw[0]
+        # Inside a hunk body: classify strictly by the leading diff marker.
+        marker = raw[0] if raw else " "
         if marker == "+":
             content = raw[1:]
             if path is not None:
@@ -89,10 +98,18 @@ def find_violations(diff_text: str) -> list[Violation]:
                     if ord(ch) > 127:
                         violations.append(Violation(path, new_lineno, idx + 1, ch))
             new_lineno += 1
-        elif marker == " ":
+            remaining_new -= 1
+        elif marker == "-":
+            # Removed lines exist only in the old file, so they are not scanned.
+            remaining_old -= 1
+        elif marker == "\\":
+            # "\ No newline at end of file" carries no line of its own; do not count it.
+            pass
+        else:
+            # Context line (marker " ", or a defensively-handled empty line): on both sides.
             new_lineno += 1
-        # "-" lines exist only in the old file, and "\ No newline at end of file" markers carry no
-        # line of their own, so neither advances the new-file line counter.
+            remaining_old -= 1
+            remaining_new -= 1
 
     return violations
 

--- a/tests/python/test_tools_check_non_ascii.py
+++ b/tests/python/test_tools_check_non_ascii.py
@@ -118,6 +118,69 @@ def test_no_newline_marker_is_ignored():
     assert violations[0].line == 1
 
 
+def test_added_line_starting_with_pluses_is_scanned_not_treated_as_header():
+    # An added source line whose content starts with "++ " (e.g. C++ prefix decrement of a deref)
+    # is emitted by git as "+++ ...". It must be scanned as an added line, not parsed as a "+++"
+    # file header (which would skip it and let its non-ASCII slip through). Regression for
+    # PR #778 review comment r3571557923.
+    diff = _diff(
+        "diff --git a/foo.cpp b/foo.cpp",
+        "--- a/foo.cpp",
+        "+++ b/foo.cpp",
+        "@@ -1,1 +1,2 @@",
+        " int main() {",
+        "+++ *p; // caf\u00e9",
+    )
+    violations = find_violations(diff)
+    assert len(violations) == 1
+    v = violations[0]
+    # Context " int main() {" is new line 1, so the added line is line 2. Content after the diff's
+    # leading "+" is "++ *p; // caf" + U+00E9 (e-acute), which sits at 0-based index 13 -> col 14.
+    assert (v.path, v.line, v.col, v.char) == ("foo.cpp", 2, 14, "\u00e9")
+
+
+def test_pluses_content_does_not_corrupt_following_file_path():
+    # If the "+++ ..." added line were mistaken for a header it would also clobber the tracked path
+    # (and drop the violation), corrupting attribution for the next file. Verify both files report.
+    diff = _diff(
+        "diff --git a/a.cpp b/a.cpp",
+        "--- a/a.cpp",
+        "+++ b/a.cpp",
+        "@@ -0,0 +1,1 @@",
+        "+++ added \u00e9",
+        "diff --git a/b.cpp b/b.cpp",
+        "--- a/b.cpp",
+        "+++ b/b.cpp",
+        "@@ -0,0 +1,1 @@",
+        "+plain \u2014 here",
+    )
+    violations = find_violations(diff)
+    assert [(v.path, v.line, v.char) for v in violations] == [
+        ("a.cpp", 1, "\u00e9"),
+        ("b.cpp", 1, "\u2014"),
+    ]
+
+
+def test_removed_line_starting_with_dashes_is_not_a_header():
+    # A removed source line starting with "-- " is emitted as "--- ...". It must not be parsed as a
+    # "--- " file header, and it must not advance the new-file line counter.
+    diff = _diff(
+        "diff --git a/foo.py b/foo.py",
+        "--- a/foo.py",
+        "+++ b/foo.py",
+        "@@ -1,2 +1,2 @@",
+        " keep",
+        "--- dashes removed",
+        "+kept \u2014 added",
+    )
+    violations = find_violations(diff)
+    assert len(violations) == 1
+    v = violations[0]
+    # " keep" is new line 1; the removed line does not advance the new counter, so the added line
+    # is new line 2. Content after "+" is "kept " + U+2014 (em dash) + " added": index 5 -> col 6.
+    assert (v.path, v.line, v.col, v.char) == ("foo.py", 2, 6, "\u2014")
+
+
 def test_describe_format():
     v = check_non_ascii.Violation(path="foo.py", line=3, col=7, char="\u2014")
     text = v.describe()


### PR DESCRIPTION
find_violations recognized "+++ "/"--- " as file headers before classifying the diff marker, so an added source line whose content starts with "++ " (git emits it as "+++ ...") was skipped -- letting its non-ASCII characters through and corrupting the tracked path and line numbers for following violations. Track hunk boundaries via the line counts in the @@ header and only treat "+++ "/"--- " as headers outside a hunk body. Adds regression tests. Ref PR #778 comment r3571557923.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
