### PR TITLE
[Bug] Respect random_seed on SPIR-V backends

### DIFF
--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -1261,6 +1261,17 @@ void GfxRuntime::init_nonroot_buffers() {
   cmdlist->buffer_fill(listgen_buffer_->get_ptr(0), kBufferSizeEntireSize,
                        /*data=*/0);
   stream->submit_synced(cmdlist.get());
+
+  // The RNG shader reads its seed from u32 element 1024 of this buffer.
+  // Metal can't buffer_fill nonzero values, so upload instead.
+  if (program_impl_ != nullptr && program_impl_->config != nullptr) {
+    const uint32_t rand_seed_state = static_cast<uint32_t>(program_impl_->config->random_seed) * 1048391u;
+    DevicePtr rand_state_ptr = global_tmps_buffer_->get_ptr(sizeof(uint32_t) * 1024);
+    const void *rand_seed_data = &rand_seed_state;
+    size_t rand_seed_size = sizeof(rand_seed_state);
+    RhiResult upload_res = device_->upload_data(&rand_state_ptr, &rand_seed_data, &rand_seed_size);
+    QD_ASSERT_INFO(upload_res == RhiResult::success, "failed to upload random seed to gtmp buffer");
+  }
 }
 
 void GfxRuntime::add_root_buffer(size_t root_buffer_size) {

--- a/tests/python/test_random.py
+++ b/tests/python/test_random.py
@@ -110,8 +110,9 @@ def test_random_seed_per_program():
 
     n = 10
     result = []
+    arch = qd.lang.impl.current_cfg().arch
     for s in [0, 1]:
-        qd.init(random_seed=s)
+        qd.init(arch=arch, random_seed=s)
         x = qd.field(qd.f32, shape=n)
 
         @qd.kernel


### PR DESCRIPTION
On Metal, setting `qd.init(random_seed=...)` didn't work and thus every seed produced the same sequence of `qd.random` numbers (the first draw is always 0.7819478511810303 -- same bug as described in taichi issue 7645).

The problem was that each GPU thread built its random-number state from its thread id, some fixed constants, and one word read from the GlobalTmps buffer (u32 element 1024). That word is the only thing that can vary between runs and where the seed has to enter.

On the LLVM backends (CPU/CUDA) there were no issues because their runtime explicitly derives every thread's starting rand state from the seed at startup (`llvm_runtime_executor.cpp`: `starting_rand_state = config_.random_seed * 1048391`). The SPIR-V backends have no equivalent step as the gfx runtime
(`runtime/gfx/runtime.cpp`) never reads `config_.random_seed` at all. It just zero-filled the GlobalTmps buffer at init and leaves it at that.

To fix that, after zeroing the buffer at program init, we write the seed into that one word, scaled by 1048391 like the LLVM runtime uses. The write uses `Device::upload_data` rather than `buffer_fill` because Metal seems to only fill buffers with zeros.

Also we fix `test_random_seed_per_program`, which should have caught this: it called `qd.init(random_seed=s)` without an arch, which silently switched to the default backend (CPU). It now re-inits with the arch under test, so it should fail on unfixed SPIR-V backends.

Issue: https://github.com/taichi-dev/taichi/issues/7645

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
