### PR TITLE
[build] Raise macOS minimum deployment target to 13.0

### DIFF
--- a/.github/workflows/scripts/qd_build/entry.py
+++ b/.github/workflows/scripts/qd_build/entry.py
@@ -34,7 +34,7 @@ def build_wheel(python: Command) -> None:
         case ("Linux", "arm64") | ("Linux", "aarch64"):
             plat = "manylinux_2_27_aarch64"
         case ("Darwin", _):
-            plat = "macosx_11_0_arm64"
+            plat = "macosx_13_0_arm64"
 
     # Clear stale wheels so the tag-stamping step below is unambiguous.
     for whl in glob.glob("dist/quadrants-*.whl"):

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,10 +5,11 @@
 cmake_minimum_required(VERSION 3.17)
 
 # macOS minimum deployment target. Set before project() so CMake bakes -mmacosx-version-min into every
-# compiled target (LC_BUILD_VERSION minos). Overridable via -DCMAKE_OSX_DEPLOYMENT_TARGET or the
-# MACOSX_DEPLOYMENT_TARGET env var. Keep in sync with the wheel platform tag in
+# compiled target (LC_BUILD_VERSION minos). Respect an explicit -DCMAKE_OSX_DEPLOYMENT_TARGET or the
+# standard MACOSX_DEPLOYMENT_TARGET env var (CMake seeds the cache from it during project()); only apply
+# our default when neither is provided. Keep in sync with the wheel platform tag in
 # .github/workflows/scripts/qd_build/entry.py (macosx_13_0_arm64).
-if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET AND "$ENV{MACOSX_DEPLOYMENT_TARGET}" STREQUAL "")
     set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS deployment target")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,14 @@
 
 cmake_minimum_required(VERSION 3.17)
 
+# macOS minimum deployment target. Set before project() so CMake bakes -mmacosx-version-min into every
+# compiled target (LC_BUILD_VERSION minos). Overridable via -DCMAKE_OSX_DEPLOYMENT_TARGET or the
+# MACOSX_DEPLOYMENT_TARGET env var. Keep in sync with the wheel platform tag in
+# .github/workflows/scripts/qd_build/entry.py (macosx_13_0_arm64).
+if(NOT DEFINED CMAKE_OSX_DEPLOYMENT_TARGET)
+    set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum macOS deployment target")
+endif()
+
 project(quadrants)
 
 include("cmake/utils.cmake")
@@ -108,7 +116,6 @@ if((LINUX OR APPLE) AND NOT IOS)
 endif()
 
 if(APPLE)
-    add_definitions(-DOSX_DEPLOYMENT_TARGET=11.0)
     add_definitions(-DTARGET_OS_OSX)
 endif()
 


### PR DESCRIPTION
Stamp the wheel as macosx_13_0_arm64 instead of macosx_11_0_arm64, and pin CMAKE_OSX_DEPLOYMENT_TARGET=13.0 (set before project()) so the compiled binary's minos matches the advertised wheel tag.

The old -DOSX_DEPLOYMENT_TARGET=11.0 define was an unused preprocessor macro that never set the real deployment target; it is replaced by the CMake variable.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
