### PR TITLE
[Bug] Gate the adstack size-expr subtraction fusion on shared source-loop provenance.

### DIFF
--- a/quadrants/ir/adstack_size_expr.h
+++ b/quadrants/ir/adstack_size_expr.h
@@ -9,6 +9,7 @@
 namespace quadrants::lang {
 
 class SNode;
+class Stmt;
 
 // Flat, offline-cache-serialisable representation of a `SizeExpr` tree. Each node references at most two operands
 // by index into the same vector; the tree root is always the last element so the evaluator can walk the vector
@@ -86,6 +87,14 @@ class SizeExpr {
   std::vector<int32_t> arg_id_path;
   int32_t arg_shape_axis{-1};
   std::vector<std::unique_ptr<SizeExpr>> operands;
+  // Only used by `MaxOverRange`, and only while `determine_ad_stack_size` is still building trees: the source IR
+  // loop whose index the range wrapper iterates, or `nullptr` for the conservative whole-axis fallback wraps that
+  // bound an index shape the pre-pass could not chase to a `LoopIndexStmt`. Two wrappers pair the same iteration
+  // only when they come from the same source loop, so `expr_sub`'s fusion keys on this pointer; alpha-equal ranges
+  // alone also match two independent fallback wraps, whose fused body would pair unrelated indices. Intentionally
+  // absent from `SerializedSizeExprNode`: the pointer is dead weight once the pass returns (fusion never runs on
+  // deserialized trees) and would dangle across the offline-cache round trip anyway.
+  Stmt *source_loop{nullptr};
 
   SizeExpr() = default;
   SizeExpr(const SizeExpr &) = delete;
@@ -129,7 +138,8 @@ class SizeExpr {
   static std::unique_ptr<SizeExpr> make_max_over_range(int32_t var_id,
                                                        std::unique_ptr<SizeExpr> begin,
                                                        std::unique_ptr<SizeExpr> end,
-                                                       std::unique_ptr<SizeExpr> body) {
+                                                       std::unique_ptr<SizeExpr> body,
+                                                       Stmt *source_loop = nullptr) {
     auto e = std::make_unique<SizeExpr>();
     e->kind = Kind::MaxOverRange;
     e->var_id = var_id;
@@ -137,6 +147,7 @@ class SizeExpr {
     e->operands.push_back(std::move(begin));
     e->operands.push_back(std::move(end));
     e->operands.push_back(std::move(body));
+    e->source_loop = source_loop;
     return e;
   }
 
@@ -170,6 +181,7 @@ class SizeExpr {
     e->var_id = var_id;
     e->arg_id_path = arg_id_path;
     e->arg_shape_axis = arg_shape_axis;
+    e->source_loop = source_loop;
     e->operands.reserve(operands.size());
     for (const auto &child : operands) {
       e->operands.push_back(child ? child->clone() : nullptr);

--- a/quadrants/transforms/determine_ad_stack_size.cpp
+++ b/quadrants/transforms/determine_ad_stack_size.cpp
@@ -286,20 +286,25 @@ std::unique_ptr<SizeExpr> expr_sub(std::unique_ptr<SizeExpr> a, std::unique_ptr<
     return SizeExpr::make_const(0);
   }
   // Fuse `Sub(MaxOverRange(X, B, E, body_a), MaxOverRange(Y, B, E, body_b))` into
-  // `MaxOverRange(X, B, E, Sub(body_a, body_b[Y->X]))` when the two wrappers are over the SAME user loop.
-  // `expr_equal` on the ends gates this via alpha-equivalence (see `expr_equal_alpha`'s comment): it only
-  // returns true when the two independently-built range wrappers bottom out at the same source IR loop, so
-  // fusing is semantically identical to the user's per-iteration paired subtraction. Without fusion the
+  // `MaxOverRange(X, B, E, Sub(body_a, body_b[Y->X]))` when the two wrappers iterate the SAME source IR loop.
+  // Fusing is then semantically identical to the user's per-iteration paired subtraction. Without fusion the
   // unfused form evaluates to `max_i body_a(i) - max_j body_b(j)` at runtime, which under-counts
   // `max_i (body_a(i) - body_b(i))` whenever the per-operand maxima are attained at different indices.
-  // Cross-user-loop fusion (two MaxOverRange wrappers from two independent enclosing loops that happen to
-  // iterate over same-axis ndarray shapes) is NOT safe: the user's two loops use independent indices, and
-  // fusing under a single `v` fabricates an index pairing that does not exist in the source - the bound
-  // collapses to `max_v (arr_a[v] - arr_b[v])` over `min(shape_a, shape_b)`, which silently misses any peak
-  // in `arr_a` past `shape_b` and drives the adstack toward overflow at `qd.sync()`. Those cases fall to
-  // the `MaxOverRange_a` over-approximation below.
+  //
+  // The `source_loop` pointer, not alpha-equivalence of the begin / end subtrees, is what proves the two
+  // wrappers share an iteration. Two wrappers built for reads at unrelated indices can carry alpha-equal ends
+  // yet pair nothing in the source: whenever an index cannot be chased to a `LoopIndexStmt`, the wrapper falls
+  // back to `MaxOverRange(v, 0, shape_along_axis)` with `source_loop == nullptr`, so a difference of two
+  // adjacent reads under one enclosing loop - `arr[i + 1] - arr[i]`, the offset-array trip count of a ragged
+  // inner loop - produces two whole-shape fallback wrappers whose ends are both the same `ExternalTensorShape`.
+  // Fusing those under a single `v` fabricates the pairing `arr[v] - arr[v]`, whose body subtracts to zero and
+  // collapses the whole inner loop's push multiplier to zero, undersizing the stack into an overflow at
+  // `qd.sync()`. Requiring a non-null shared `source_loop` keeps the fusion for genuinely paired reads and
+  // routes every fallback-wrapped difference to the `MaxOverRange_a` over-approximation below, which stays a
+  // sound upper bound (`max(0, a - b) <= a` for non-negative `b`).
   if (a->kind == SizeExpr::Kind::MaxOverRange && b->kind == SizeExpr::Kind::MaxOverRange && a->operands.size() == 3 &&
-      b->operands.size() == 3 && expr_equal(a->operands[0].get(), b->operands[0].get()) &&
+      b->operands.size() == 3 && a->source_loop != nullptr && a->source_loop == b->source_loop &&
+      expr_equal(a->operands[0].get(), b->operands[0].get()) &&
       expr_equal(a->operands[1].get(), b->operands[1].get())) {
     // Decline the fusion when the resulting body would mix a `FieldLoad` and an `ExternalTensorRead`. Each
     // side is independently host-foldable (its MaxOverRange wraps a closed subtree), but the fused body
@@ -316,13 +321,15 @@ std::unique_ptr<SizeExpr> expr_sub(std::unique_ptr<SizeExpr> a, std::unique_ptr<
     if (!would_mix) {
       int32_t var_x = a->var_id;
       int32_t var_y = b->var_id;
+      // Both wrappers share this loop (gated above), so the fused wrapper iterates it too.
+      Stmt *fused_loop = a->source_loop;
       auto body_b_renamed = b->operands[2] ? b->operands[2]->clone() : nullptr;
       if (body_b_renamed != nullptr && var_x != var_y) {
         substitute_var_in_place(body_b_renamed.get(), var_y, var_x);
       }
       auto new_body = expr_sub(std::move(a->operands[2]), std::move(body_b_renamed));
       return SizeExpr::make_max_over_range(var_x, std::move(a->operands[0]), std::move(a->operands[1]),
-                                           std::move(new_body));
+                                           std::move(new_body), fused_loop);
     }
   }
   // Sound upper bound on `Sub(a, b)` when both operands are `MaxOverRange` and we could not fuse them (cross-
@@ -739,7 +746,8 @@ std::unique_ptr<SizeExpr> build_value_expr(Stmt *stmt, IRNode *root, int32_t *va
         if (!begin_e || !end_e) {
           return nullptr;
         }
-        result = SizeExpr::make_max_over_range(wrap.var_id, std::move(begin_e), std::move(end_e), std::move(result));
+        result = SizeExpr::make_max_over_range(wrap.var_id, std::move(begin_e), std::move(end_e), std::move(result),
+                                               wrap.loop);
       }
       return result;
     }
@@ -852,7 +860,8 @@ std::unique_ptr<SizeExpr> build_value_expr(Stmt *stmt, IRNode *root, int32_t *va
         if (!begin_e || !end_e) {
           return nullptr;
         }
-        result = SizeExpr::make_max_over_range(var_id, std::move(begin_e), std::move(end_e), std::move(result));
+        result =
+            SizeExpr::make_max_over_range(var_id, std::move(begin_e), std::move(end_e), std::move(result), range_for);
       }
       return result;
     }
@@ -1008,7 +1017,8 @@ std::unique_ptr<SizeExpr> build_value_expr(Stmt *stmt, IRNode *root, int32_t *va
         if (!begin_e || !end_e) {
           return nullptr;
         }
-        result = SizeExpr::make_max_over_range(wrap.var_id, std::move(begin_e), std::move(end_e), std::move(result));
+        result = SizeExpr::make_max_over_range(wrap.var_id, std::move(begin_e), std::move(end_e), std::move(result),
+                                               wrap.loop);
       }
       return result;
     }

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5202,18 +5202,13 @@ def test_above_cap_out_of_grammar_kernel_raises():
 
 @test_utils.test(require=qd.extension.adstack, cfg_optimization=False)
 def test_adstack_offset_array_difference_loop_trip_grad_correct():
-    # A reverse-mode kernel whose inner loop trip count is the difference of two adjacent reads of an offset array
-    # (`starts[i + 1] - starts[i]`, the ragged-segment length pattern) must size the loop-carried adstack for the
-    # widest segment, and the analytical gradient must match the closed form. The structural pre-pass wraps each of
-    # the two reads in a whole-shape `MaxOverRange` fallback because the recovered loop index is opaque; the two
-    # wrappers carry alpha-equal `ExternalTensorShape` ends, so before the fix `expr_sub` fused them into
-    # `MaxOverRange(starts[v] - starts[v]) = 0`, collapsing the loop's push multiplier to zero. The stack was then
-    # sized for the root pushes only and overflowed once a segment had more than one element (loud
-    # `QuadrantsAssertionError` on SPIR-V, silently replicated per-lane gradients on a `__debug__`-disabled build).
-    # The outer parallel `ndrange` forces the reverse pass to spill and recover the loop index (via a stash), so
-    # both `starts` reads index through an opaque expression and take the whole-shape `MaxOverRange` fallback -
-    # the shape that fuses to zero before the fix. A compile-time outer `range` would keep the index concrete and
-    # not exercise the fusion.
+    # Inner loop trip count is the difference of two adjacent offset-array reads (`starts[i + 1] - starts[i]`, the
+    # ragged-segment length pattern); the adstack must be sized for the widest segment. The outer parallel `ndrange`
+    # forces the reverse pass to spill and recover the loop index, so both reads index through an opaque expression
+    # and each takes a whole-shape `MaxOverRange` fallback with alpha-equal `ExternalTensorShape` ends. Before the
+    # fix `expr_sub` fused those into `MaxOverRange(starts[v] - starts[v]) = 0`, zeroing the loop's push multiplier:
+    # the stack was sized for the root pushes only and overflowed for any segment longer than one (loud on SPIR-V,
+    # silently per-lane-replicated gradients on a `__debug__`-disabled build).
     starts_np = np.array([0, 2, 3, 6], dtype=np.int32)  # segment lengths 2, 1, 3
     n_seg = starts_np.size - 1
     total = int(starts_np[-1])

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5205,23 +5205,22 @@ def test_adstack_offset_array_difference_loop_trip_grad_correct():
     # Inner loop trip count is the difference of two adjacent offset-array reads (`starts[i + 1] - starts[i]`, the
     # ragged-segment length pattern); the adstack must be sized for the widest segment. The outer parallel `ndrange`
     # forces the reverse pass to spill and recover the loop index, so both reads index through an opaque expression
-    # and each takes a whole-shape `MaxOverRange` fallback with alpha-equal `ExternalTensorShape` ends. Before the
-    # fix `expr_sub` fused those into `MaxOverRange(starts[v] - starts[v]) = 0`, zeroing the loop's push multiplier:
-    # the stack was sized for the root pushes only and overflowed for any segment longer than one (loud on SPIR-V,
-    # silently per-lane-replicated gradients on a `__debug__`-disabled build).
+    # and each takes a whole-shape `MaxOverRange` fallback with alpha-equal shape ends. Before the fix `expr_sub`
+    # fused those into `MaxOverRange(starts[v] - starts[v]) = 0`, zeroing the loop's push multiplier: the stack was
+    # sized for the root pushes only and overflowed for any segment longer than one (loud on SPIR-V, silently
+    # per-lane-replicated gradients on a `__debug__`-disabled build).
     starts_np = np.array([0, 2, 3, 6], dtype=np.int32)  # segment lengths 2, 1, 3
     n_seg = starts_np.size - 1
     total = int(starts_np[-1])
     n_env = 2
     x_np = np.linspace(0.2, 0.9, total * n_env).astype(np.float32).reshape(total, n_env)
 
-    starts = qd.ndarray(qd.i32, shape=(n_seg + 1,))
-    starts.from_numpy(starts_np)
-    x = qd.ndarray(qd.f32, shape=(total, n_env), needs_grad=True)
-    out = qd.ndarray(qd.f32, shape=(n_seg, n_env), needs_grad=True)
+    starts = qd.field(qd.i32, shape=n_seg + 1)
+    x = qd.field(qd.f32, shape=(total, n_env), needs_grad=True)
+    out = qd.field(qd.f32, shape=(n_seg, n_env), needs_grad=True)
 
     @qd.kernel
-    def compute(x: qd.types.ndarray(), out: qd.types.ndarray(), starts: qd.types.ndarray()):
+    def compute():
         for i, i_env in qd.ndrange(n_seg, n_env):
             seg_start = starts[i]
             seg_end = starts[i + 1]
@@ -5230,11 +5229,12 @@ def test_adstack_offset_array_difference_loop_trip_grad_correct():
                 acc = acc + x[seg_start + j, i_env] * x[seg_start + j, i_env]
             out[i, i_env] = acc
 
+    starts.from_numpy(starts_np)
     x.from_numpy(x_np)
-    compute(x, out, starts)
+    compute()
     out.grad.from_numpy(np.ones((n_seg, n_env), dtype=np.float32))
     x.grad.fill(0.0)
-    compute.grad(x, out, starts)
+    compute.grad()
 
     # out[i, e] = sum_{j in segment i} x[j, e]^2, so d(out)/d(x[j, e]) = 2 * x[j, e] for the owning segment.
     grad = x.grad.to_numpy()

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5198,3 +5198,51 @@ def test_above_cap_out_of_grammar_kernel_raises():
             x.grad[i] = 0.0
         compute.grad(a)
         qd.sync()
+
+
+@test_utils.test(require=qd.extension.adstack, cfg_optimization=False)
+def test_adstack_offset_array_difference_loop_trip_grad_correct():
+    # A reverse-mode kernel whose inner loop trip count is the difference of two adjacent reads of an offset array
+    # (`starts[i + 1] - starts[i]`, the ragged-segment length pattern) must size the loop-carried adstack for the
+    # widest segment, and the analytical gradient must match the closed form. The structural pre-pass wraps each of
+    # the two reads in a whole-shape `MaxOverRange` fallback because the recovered loop index is opaque; the two
+    # wrappers carry alpha-equal `ExternalTensorShape` ends, so before the fix `expr_sub` fused them into
+    # `MaxOverRange(starts[v] - starts[v]) = 0`, collapsing the loop's push multiplier to zero. The stack was then
+    # sized for the root pushes only and overflowed once a segment had more than one element (loud
+    # `QuadrantsAssertionError` on SPIR-V, silently replicated per-lane gradients on a `__debug__`-disabled build).
+    # The outer parallel `ndrange` forces the reverse pass to spill and recover the loop index (via a stash), so
+    # both `starts` reads index through an opaque expression and take the whole-shape `MaxOverRange` fallback -
+    # the shape that fuses to zero before the fix. A compile-time outer `range` would keep the index concrete and
+    # not exercise the fusion.
+    starts_np = np.array([0, 2, 3, 6], dtype=np.int32)  # segment lengths 2, 1, 3
+    n_seg = starts_np.size - 1
+    total = int(starts_np[-1])
+    n_env = 2
+    x_np = np.linspace(0.2, 0.9, total * n_env).astype(np.float32).reshape(total, n_env)
+
+    starts = qd.ndarray(qd.i32, shape=(n_seg + 1,))
+    starts.from_numpy(starts_np)
+    x = qd.ndarray(qd.f32, shape=(total, n_env), needs_grad=True)
+    out = qd.ndarray(qd.f32, shape=(n_seg, n_env), needs_grad=True)
+
+    @qd.kernel
+    def compute(x: qd.types.ndarray(), out: qd.types.ndarray(), starts: qd.types.ndarray()):
+        for i, i_env in qd.ndrange(n_seg, n_env):
+            seg_start = starts[i]
+            seg_end = starts[i + 1]
+            acc = qd.f32(0.0)
+            for j in range(seg_end - seg_start):
+                acc = acc + x[seg_start + j, i_env] * x[seg_start + j, i_env]
+            out[i, i_env] = acc
+
+    x.from_numpy(x_np)
+    compute(x, out, starts)
+    out.grad.from_numpy(np.ones((n_seg, n_env), dtype=np.float32))
+    x.grad.fill(0.0)
+    compute.grad(x, out, starts)
+
+    # out[i, e] = sum_{j in segment i} x[j, e]^2, so d(out)/d(x[j, e]) = 2 * x[j, e] for the owning segment.
+    grad = x.grad.to_numpy()
+    for j in range(total):
+        for e in range(n_env):
+            assert grad[j, e] == pytest.approx(2.0 * x_np[j, e], rel=1e-5)


### PR DESCRIPTION
Issue: #791

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
