### PR TITLE
[Bug] Fix the reverse-mode gradient of a loop-carried vector rebuilt across a dynamic loop.

### DIFF
--- a/quadrants/transforms/auto_diff/auto_diff_common.h
+++ b/quadrants/transforms/auto_diff/auto_diff_common.h
@@ -60,6 +60,48 @@ class NonLinearOps {
                                                                 BinaryOpType::min,   BinaryOpType::max};
 };
 
+// Recognize the stack-materialization shape `ReplaceLocalVarWithStacks` emits to subscript a stack-backed tensor's
+// current top: a `LocalLoadStmt(MatrixPtrStmt(alloca, const_offset))` where `alloca` is a fresh `AllocaStmt` written by
+// exactly one full-tensor `LocalStoreStmt` (no partial or atomic writes), placed before the load in the same block.
+// That single store's value is the loaded tensor top; the alloca exists only so the forward store-to-load walker can
+// trace the read (`AdStackPushStmt` is not a reaching def). Returns the store's value, or nullptr when the load does
+// not match. The reverse pass uses this to reconstruct the per-iteration component from the recomputable top instead
+// of spilling the last iteration's value through a single overwrite-each-iteration alloca.
+inline Stmt *ad_stack_materialization_source(LocalLoadStmt *ll) {
+  auto *mp = ll->src != nullptr ? ll->src->cast<MatrixPtrStmt>() : nullptr;
+  if (mp == nullptr || mp->offset == nullptr || !mp->offset->is<ConstStmt>())
+    return nullptr;
+  auto *alloca = mp->origin != nullptr ? mp->origin->cast<AllocaStmt>() : nullptr;
+  Block *block = ll->parent;
+  if (alloca == nullptr || block == nullptr || alloca->parent != block)
+    return nullptr;
+  Stmt *store_val = nullptr;
+  int store_pos = -1;
+  int load_pos = -1;
+  int write_count = 0;
+  for (int i = 0; i < (int)block->statements.size(); i++) {
+    Stmt *s = block->statements[i].get();
+    if (s == ll) {
+      load_pos = i;
+    } else if (auto *st = s->cast<LocalStoreStmt>()) {
+      if (st->dest == alloca) {
+        store_val = st->val;
+        store_pos = i;
+        write_count++;
+      } else if (auto *dst_mp = st->dest->cast<MatrixPtrStmt>()) {
+        if (dst_mp->origin == alloca)
+          write_count++;
+      }
+    } else if (auto *ao = s->cast<AtomicOpStmt>()) {
+      if (ao->dest == alloca)
+        write_count++;
+    }
+  }
+  if (store_val == nullptr || write_count != 1 || store_pos < 0 || load_pos < 0 || store_pos >= load_pos)
+    return nullptr;
+  return store_val;
+}
+
 // ----------------------------------------------------------------------------
 // Recomputable chain analyzer + cloner: decide whether a forward SSA value can be reconstructed in the reverse-pass
 // scope from already-stack-backed allocas, kernel args, constants, and loop indices, and clone the DAG at a target

--- a/quadrants/transforms/auto_diff/forward_state_spill.cpp
+++ b/quadrants/transforms/auto_diff/forward_state_spill.cpp
@@ -181,6 +181,15 @@ class AdStackAllocaJudger : public BasicStmtVisitor {
     if (stmt->src == target_alloca_) {
       local_loaded_ = true;
       target_alloca_ = stmt;
+      return;
+    }
+    // Tensor-typed allocas are read component-wise through a `MatrixPtrStmt` (`shift ptr [alloca + i]`), so the
+    // load's `src` is the MatrixPtr, not the alloca. Without matching this shape the load+store recurrence rule in
+    // `visit(LocalStoreStmt)` never fires for a loop-carried tensor local: it stays a single overwrite-each-iteration
+    // slot, and the reverse pass reads only the last forward iteration's value for every reverse iteration.
+    if (auto *mp = stmt->src->cast<MatrixPtrStmt>()) {
+      if (mp->origin == target_alloca_backup_)
+        local_loaded_ = true;
     }
   }
 

--- a/quadrants/transforms/auto_diff/post_adjoint_cleanup.cpp
+++ b/quadrants/transforms/auto_diff/post_adjoint_cleanup.cpp
@@ -84,6 +84,39 @@ class BackupSSA : public BasicStmtVisitor {
           }
         } else if (op->is<ArgLoadStmt>()) {
           stmt->set_operand(i, stmt->insert_before_me(op->clone()));
+        } else if (Stmt *top_val =
+                       op->is<LocalLoadStmt>() ? ad_stack_materialization_source(op->as<LocalLoadStmt>()) : nullptr) {
+          // `op` reads one component of a stack-backed tensor's top through a fresh materialization alloca (see
+          // `ad_stack_materialization_source`). The plain alloca is not recomputable, so the generic `load(op)` spill
+          // below would back it with a single overwrite-each-iteration slot and every reverse iteration would read the
+          // last forward iteration's component. Reconstruct the read instead: clone the recomputable full-tensor top at
+          // the reverse cursor (per-iteration correct under the same pop-ordering the AdStackLoadTopStmt clone relies
+          // on), re-materialize it into a fresh alloca, and re-subscript at the same constant offset.
+          auto *ll = op->as<LocalLoadStmt>();
+          auto *mp = ll->src->as<MatrixPtrStmt>();
+          if (RecomputableChainAnalyzer::is_recomputable(top_val, recomputable_cache_, mutated_snodes_) &&
+              is_chain_clone_safe(top_val, stmt)) {
+            std::unordered_map<Stmt *, Stmt *> clone_cache;
+            Stmt *cloned_top = RecomputableChainCloner::clone_at(top_val, stmt, clone_cache);
+            auto tensor_type = mp->origin->ret_type.ptr_removed();
+            auto fresh_alloca = Stmt::make<AllocaStmt>(tensor_type);
+            auto *fresh_alloca_ptr = fresh_alloca.get();
+            fresh_alloca->ret_type = tensor_type;
+            fresh_alloca->ret_type.set_is_pointer(true);
+            auto cloned_offset = stmt->insert_before_me(mp->offset->clone());
+            stmt->insert_before_me(std::move(fresh_alloca));
+            stmt->insert_before_me(Stmt::make<LocalStoreStmt>(fresh_alloca_ptr, cloned_top));
+            auto new_mp = Stmt::make<MatrixPtrStmt>(fresh_alloca_ptr, cloned_offset);
+            new_mp->ret_type = ll->ret_type;
+            auto *new_mp_ptr = new_mp.get();
+            stmt->insert_before_me(std::move(new_mp));
+            auto new_load = Stmt::make<LocalLoadStmt>(new_mp_ptr);
+            new_load->ret_type = ll->ret_type;
+            stmt->set_operand(i, stmt->insert_before_me(std::move(new_load)));
+          } else {
+            auto alloca = load(op);
+            stmt->set_operand(i, stmt->insert_before_me(Stmt::make<LocalLoadStmt>(alloca)));
+          }
         } else {
           // Recomputable-chain fallback before the last-iter `load(op)` spill: when the cross-block SSA op is rooted in
           // a DAG of side-effect-free arithmetic over already-stack-backed allocas, kernel-args, constants, and loop

--- a/quadrants/transforms/scalarize.cpp
+++ b/quadrants/transforms/scalarize.cpp
@@ -719,6 +719,15 @@ class Scalarize : public BasicStmtVisitor {
         auto scalar_ad_stack = std::make_unique<AdStackAllocaStmt>(element_type, stmt->max_size);
         scalar_ad_stack->ret_type = element_type;
         scalar_ad_stack->ret_type.set_is_pointer(true);
+        // Carry the per-launch size bound onto each scalar component. `determine_ad_stack_size` runs before this
+        // pass and, for an adaptive tensor-typed stack, records a `size_expr` while leaving `max_size` at the seed
+        // value of 1 for the runtime to overwrite. Every component is pushed and popped in lockstep with the tensor
+        // stack, so they share its depth exactly; without cloning `size_expr` the component keeps only the seed
+        // `max_size`, the launcher finds no symbolic tree and sizes the heap to that seed, and a scalar stack pushed
+        // inside a runtime-bounded loop overflows once the loop runs more than once.
+        if (stmt->size_expr) {
+          scalar_ad_stack->size_expr = stmt->size_expr->clone();
+        }
 
         scalarized_ad_stack.push_back(scalar_ad_stack.get());
         delayed_modifier_.insert_before(stmt, std::move(scalar_ad_stack));

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5207,39 +5207,39 @@ def test_adstack_scalarized_tensor_component_loop_trip_grad_correct():
     # seed 1. The later scalarize pass splits the tensor stack into per-component scalar stacks; before the fix the
     # split dropped `size_expr`, so each component kept only the seed and overflowed once the loop ran more than once
     # (loud on SPIR-V, silently per-lane-replicated gradients on a `__debug__`-disabled build).
-    n_iter_np = np.array([3], dtype=np.int32)
+    n_iter_val = 3
     denom_val = 2.0
     x_np = np.array([0.3, 0.7], dtype=np.float32)
     n_env = x_np.size
 
-    n_iter = qd.ndarray(qd.i32, shape=(1,))
-    n_iter.from_numpy(n_iter_np)
-    denom = qd.ndarray(qd.f32, shape=(1,))
-    denom.from_numpy(np.array([denom_val], dtype=np.float32))
-    x = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
-    out = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
+    n_iter = qd.field(qd.i32, shape=())
+    denom = qd.field(qd.f32, shape=())
+    x = qd.field(qd.f32, shape=n_env, needs_grad=True)
+    out = qd.field(qd.f32, shape=n_env, needs_grad=True)
 
     @qd.kernel
-    def compute(x: qd.types.ndarray(), out: qd.types.ndarray(), n_iter: qd.types.ndarray(), denom: qd.types.ndarray()):
+    def compute():
         for i in range(n_env):
             q = qd.Vector([x[i], x[i] * 0.5], dt=qd.f32)
-            s = denom[0]
-            for _ in range(n_iter[0]):
+            s = denom[None]
+            for _ in range(n_iter[None]):
                 q = qd.Vector([q[0] + q[1] * 0.1, q[1] + q[0] * 0.2], dt=qd.f32)
                 q = q / s
             out[i] = q[0] + q[1]
 
+    n_iter[None] = n_iter_val
+    denom[None] = denom_val
     x.from_numpy(x_np)
-    compute(x, out, n_iter, denom)
+    compute()
     out.grad.from_numpy(np.ones(n_env, dtype=np.float32))
     x.grad.fill(0.0)
-    compute.grad(x, out, n_iter, denom)
+    compute.grad()
 
     # The recurrence q <- (M @ q) / s with M = [[1, 0.1], [0.2, 1]] is linear, so d(out)/d(x[i]) is the same for
     # every env: sum of the columns of (M / s)^n_iter applied to the initial jacobian (1, 0.5).
     mat = np.array([[1.0, 0.1], [0.2, 1.0]], dtype=np.float64) / denom_val
     jac = np.array([1.0, 0.5], dtype=np.float64)
-    for _ in range(int(n_iter_np[0])):
+    for _ in range(n_iter_val):
         jac = mat @ jac
     expected = float(jac.sum())
     grad = x.grad.to_numpy()

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5245,3 +5245,40 @@ def test_adstack_scalarized_tensor_component_loop_trip_grad_correct():
     grad = x.grad.to_numpy()
     for i in range(n_env):
         assert grad[i] == pytest.approx(expected, rel=1e-5)
+
+
+@test_utils.test(require=qd.extension.adstack, cfg_optimization=False)
+def test_adstack_loop_carried_vector_component_grad_correct():
+    # A multi-component `qd.Vector` carried across a field-bounded loop and rebuilt from its own previous components
+    # each iteration must have its reverse-mode gradient read each iteration's component value, not the last one. The
+    # loop-carried tensor local is read component-wise through a `MatrixPtr`, so before the fix the adstack judge never
+    # saw a load of it and left it a single overwrite-each-iteration slot; the reverse then read the final iteration's
+    # component for every reverse step, scaling the second-order term of the gradient by a spurious extra factor. The
+    # scalar-valued analogue was already correct, so this guards specifically the tensor component read off the stack.
+    n_iter_np = np.array([2], dtype=np.int32)
+    x_np = np.array([0.3, 0.7], dtype=np.float32)
+    n_env = x_np.size
+
+    n_iter = qd.ndarray(qd.i32, shape=(1,))
+    n_iter.from_numpy(n_iter_np)
+    x = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
+    out = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
+
+    @qd.kernel
+    def compute(x: qd.types.ndarray(), out: qd.types.ndarray(), n_iter: qd.types.ndarray()):
+        for i_env in range(n_env):
+            q = qd.Vector([x[i_env], x[i_env] * 0.5], dt=qd.f32)
+            for _ in range(n_iter[0]):
+                q = qd.Vector([q[0] * q[0], q[1] + q[0] * 0.1], dt=qd.f32)
+            out[i_env] = q[1]
+
+    x.from_numpy(x_np)
+    compute(x, out, n_iter)
+    out.grad.from_numpy(np.ones(n_env, dtype=np.float32))
+    x.grad.fill(0.0)
+    compute.grad(x, out, n_iter)
+
+    # After two iterations out = 0.6 * x + 0.1 * x^2, so d(out)/dx = 0.6 + 0.2 * x.
+    grad = x.grad.to_numpy()
+    for i in range(n_env):
+        assert grad[i] == pytest.approx(0.6 + 0.2 * x_np[i], rel=1e-5)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5255,28 +5255,27 @@ def test_adstack_loop_carried_vector_component_grad_correct():
     # saw a load of it and left it a single overwrite-each-iteration slot; the reverse then read the final iteration's
     # component for every reverse step, scaling the second-order term of the gradient by a spurious extra factor. The
     # scalar-valued analogue was already correct, so this guards specifically the tensor component read off the stack.
-    n_iter_np = np.array([2], dtype=np.int32)
+    n_env = 2
     x_np = np.array([0.3, 0.7], dtype=np.float32)
-    n_env = x_np.size
 
-    n_iter = qd.ndarray(qd.i32, shape=(1,))
-    n_iter.from_numpy(n_iter_np)
-    x = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
-    out = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
+    n_iter = qd.field(qd.i32, shape=())
+    x = qd.field(qd.f32, shape=n_env, needs_grad=True)
+    out = qd.field(qd.f32, shape=n_env, needs_grad=True)
 
     @qd.kernel
-    def compute(x: qd.types.ndarray(), out: qd.types.ndarray(), n_iter: qd.types.ndarray()):
+    def compute():
         for i_env in range(n_env):
             q = qd.Vector([x[i_env], x[i_env] * 0.5], dt=qd.f32)
-            for _ in range(n_iter[0]):
+            for _ in range(n_iter[None]):
                 q = qd.Vector([q[0] * q[0], q[1] + q[0] * 0.1], dt=qd.f32)
             out[i_env] = q[1]
 
+    n_iter[None] = 2
     x.from_numpy(x_np)
-    compute(x, out, n_iter)
+    compute()
     out.grad.from_numpy(np.ones(n_env, dtype=np.float32))
     x.grad.fill(0.0)
-    compute.grad(x, out, n_iter)
+    compute.grad()
 
     # After two iterations out = 0.6 * x + 0.1 * x^2, so d(out)/dx = 0.6 + 0.2 * x.
     grad = x.grad.to_numpy()

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5202,13 +5202,11 @@ def test_above_cap_out_of_grammar_kernel_raises():
 
 @test_utils.test(require=qd.extension.adstack, cfg_optimization=False)
 def test_adstack_scalarized_tensor_component_loop_trip_grad_correct():
-    # A reverse-mode kernel with a tensor-valued loop-carried variable divided by a scalar inside a field-bounded
-    # loop must size each scalar component of the adstack for the full trip count. `determine_ad_stack_size` records
-    # a `size_expr` on the tensor-typed adstack while leaving `max_size` at the seed 1; the later scalarize pass
-    # splits the tensor stack into per-component scalar stacks. Before the fix the split dropped `size_expr`, so each
-    # component kept only the seed and overflowed once the loop ran more than once (loud on SPIR-V, silently
-    # replicated per-lane gradients on a `__debug__`-disabled build). The vector-by-scalar division keeps the value
-    # tensor-typed past the pre-pass so the split happens after sizing.
+    # A tensor-valued loop-carried variable divided by a scalar (`q / q.norm()`) stays tensor-typed past
+    # `determine_ad_stack_size`, which records a `size_expr` on the tensor adstack while leaving `max_size` at the
+    # seed 1. The later scalarize pass splits the tensor stack into per-component scalar stacks; before the fix the
+    # split dropped `size_expr`, so each component kept only the seed and overflowed once the loop ran more than once
+    # (loud on SPIR-V, silently per-lane-replicated gradients on a `__debug__`-disabled build).
     n_iter_np = np.array([3], dtype=np.int32)
     denom_val = 2.0
     x_np = np.array([0.3, 0.7], dtype=np.float32)

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5198,3 +5198,52 @@ def test_above_cap_out_of_grammar_kernel_raises():
             x.grad[i] = 0.0
         compute.grad(a)
         qd.sync()
+
+
+@test_utils.test(require=qd.extension.adstack, cfg_optimization=False)
+def test_adstack_scalarized_tensor_component_loop_trip_grad_correct():
+    # A reverse-mode kernel with a tensor-valued loop-carried variable divided by a scalar inside a field-bounded
+    # loop must size each scalar component of the adstack for the full trip count. `determine_ad_stack_size` records
+    # a `size_expr` on the tensor-typed adstack while leaving `max_size` at the seed 1; the later scalarize pass
+    # splits the tensor stack into per-component scalar stacks. Before the fix the split dropped `size_expr`, so each
+    # component kept only the seed and overflowed once the loop ran more than once (loud on SPIR-V, silently
+    # replicated per-lane gradients on a `__debug__`-disabled build). The vector-by-scalar division keeps the value
+    # tensor-typed past the pre-pass so the split happens after sizing.
+    n_iter_np = np.array([3], dtype=np.int32)
+    denom_val = 2.0
+    x_np = np.array([0.3, 0.7], dtype=np.float32)
+    n_env = x_np.size
+
+    n_iter = qd.ndarray(qd.i32, shape=(1,))
+    n_iter.from_numpy(n_iter_np)
+    denom = qd.ndarray(qd.f32, shape=(1,))
+    denom.from_numpy(np.array([denom_val], dtype=np.float32))
+    x = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
+    out = qd.ndarray(qd.f32, shape=(n_env,), needs_grad=True)
+
+    @qd.kernel
+    def compute(x: qd.types.ndarray(), out: qd.types.ndarray(), n_iter: qd.types.ndarray(), denom: qd.types.ndarray()):
+        for i in range(n_env):
+            q = qd.Vector([x[i], x[i] * 0.5], dt=qd.f32)
+            s = denom[0]
+            for _ in range(n_iter[0]):
+                q = qd.Vector([q[0] + q[1] * 0.1, q[1] + q[0] * 0.2], dt=qd.f32)
+                q = q / s
+            out[i] = q[0] + q[1]
+
+    x.from_numpy(x_np)
+    compute(x, out, n_iter, denom)
+    out.grad.from_numpy(np.ones(n_env, dtype=np.float32))
+    x.grad.fill(0.0)
+    compute.grad(x, out, n_iter, denom)
+
+    # The recurrence q <- (M @ q) / s with M = [[1, 0.1], [0.2, 1]] is linear, so d(out)/d(x[i]) is the same for
+    # every env: sum of the columns of (M / s)^n_iter applied to the initial jacobian (1, 0.5).
+    mat = np.array([[1.0, 0.1], [0.2, 1.0]], dtype=np.float64) / denom_val
+    jac = np.array([1.0, 0.5], dtype=np.float64)
+    for _ in range(int(n_iter_np[0])):
+        jac = mat @ jac
+    expected = float(jac.sum())
+    grad = x.grad.to_numpy()
+    for i in range(n_env):
+        assert grad[i] == pytest.approx(expected, rel=1e-5)


### PR DESCRIPTION
Issue: #797

Stacked on #796 (the scalarize `size_expr` propagation): promoting a loop-carried tensor to an adstack relies on that fix to size the scalar component stacks. Review/merge #796 first; this PR's base will retarget to `main` once #796 lands.

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
