### PR TITLE
[Lang] Cut per-compilation Python overhead (sys.modules scan + per-node source formatting)

### DIFF
--- a/python/quadrants/lang/ast/ast_transformer_utils.py
+++ b/python/quadrants/lang/ast/ast_transformer_utils.py
@@ -35,7 +35,11 @@ class Builder:
             if method is None:
                 error_msg = f'Unsupported node "{node.__class__.__name__}"'
                 raise QuadrantsSyntaxError(error_msg)
-            info = ctx.get_pos_info(node) if isinstance(node, (ast.stmt, ast.expr)) else ""
+            # Attach only the cheap file/line/function header to every IR node. Building the full source-line
+            # hint (get_pos_info) here means running TextWrapper for every AST node of every kernel compilation,
+            # which dominates kernel build time. The full hint is still produced on the actual compile-error path
+            # below (get_pos_info in the except handler), so error messages are unchanged.
+            info = ctx.get_pos_header(node) if isinstance(node, (ast.stmt, ast.expr)) else ""
             with impl.get_runtime().src_info_guard(info):
                 res = method(ctx, node)
                 if not hasattr(node, "violates_pure"):
@@ -387,8 +391,11 @@ class ASTTransformerFuncContext:
         except AttributeError:
             raise QuadrantsNameError(f'Name "{name}" is not defined')
 
+    def get_pos_header(self, node: ast.AST) -> str:
+        return f'File "{self.file}", line {node.lineno + self.lineno_offset}, in {self.func.func.__name__}:\n'
+
     def get_pos_info(self, node: ast.AST) -> str:
-        msg = f'File "{self.file}", line {node.lineno + self.lineno_offset}, in {self.func.func.__name__}:\n'
+        msg = self.get_pos_header(node)
         col_offset = self.indent + node.col_offset
         end_col_offset = self.indent + node.end_col_offset
 

--- a/python/quadrants/lang/kernel_impl.py
+++ b/python/quadrants/lang/kernel_impl.py
@@ -1,4 +1,4 @@
-import inspect
+import linecache
 import re
 import sys
 import typing
@@ -141,10 +141,13 @@ _KERNEL_CLASS_STACKFRAME_STMT_RES = [
 def _inside_class(level_of_class_stackframe: int) -> bool:
     try:
         maybe_class_frame = sys._getframe(level_of_class_stackframe)
-        statement_list = inspect.getframeinfo(maybe_class_frame)[3]
-        if statement_list is None:
+        # Read the decoration-site source line via linecache rather than inspect.getframeinfo: getframeinfo
+        # resolves the frame's module through inspect.getmodule, an O(len(sys.modules)) scan run once per kernel
+        # creation. With thousands of modules loaded this dominates kernel build time; linecache.getline returns
+        # the same source line with no such scan.
+        first_statment = linecache.getline(maybe_class_frame.f_code.co_filename, maybe_class_frame.f_lineno).strip()
+        if not first_statment:
             return False
-        first_statment = statement_list[0].strip()
         for pat in _KERNEL_CLASS_STACKFRAME_STMT_RES:
             if pat.match(first_statment):
                 return True


### PR DESCRIPTION
Two independent reductions of Python-side overhead paid on every kernel compilation. Both are pure
performance changes with no functional effect on generated kernels.

## 1. Class-kernel detection: drop the `sys.modules` scan

`_inside_class` runs once per kernel creation and used `inspect.getframeinfo(frame)`, which resolves the
frame's module through `inspect.getmodule` — an `O(len(sys.modules))` scan over every loaded module. In
applications importing many modules (a full physics/ML stack, several thousand modules) this runs on every
kernel materialization and dominates kernel build time. Replaced with `linecache.getline(co_filename,
f_lineno)`, which returns the same decoration-site line without touching `sys.modules`. `inspect` is no
longer needed here.

## 2. Kernel build: attach only a cheap source header per AST node

`ASTTransformer` attached full source-position info to every generated IR node via `get_pos_info`, which
builds a `TextWrapper`-formatted source-line-plus-caret hint for each node. That formatting ran for every
AST node of every kernel compilation. Now the eager per-node path attaches only the cheap
`File "...", line N, in fn` header (`get_pos_header`); the full hint is still produced on the actual
compile-error path (the `except` handler calls `get_pos_info`), so compile-error messages are unchanged.

## Impact

Full-suite measurement on the Genesis test suite (1186 tests, 8 GPUs, forked; both changes vs the unpatched
baseline, same `Scene.build` instrumentation for both):

- total `Scene.build`: **58,094s -> 50,808s (-12.5%)**
- total test call time: **74,225s -> 66,691s (-10.2%)**
- all tests pass (1186 passed)

Approximate per-lever split — the **combined** figure above is measured; the split below is **inferred**
(from the isolation A/B plus a gutted-formatting run), not independently measured:

- **#2 (per-node source formatting)** carries most of it: **~-10%** of `Scene.build` suite-wide.
- **#1 (`sys.modules` scan)**: **~-2%** of `Scene.build` suite-wide, but **~+20%** in isolation on small,
  build-light tests (it removes an `O(sys.modules)` scan paid per kernel creation, which dominates a tiny
  build but is a small slice of a large one).

Isolation A/B on a single kernel-build-heavy test (interleaved, warm caches): median wall ~29.6s -> ~25.7s.
