### PR TITLE
[Bug] Fix SPIR-V dominance of the adstack heap stride loads.

### DIFF
--- a/quadrants/codegen/spirv/detail/spirv_codegen.h
+++ b/quadrants/codegen/spirv/detail/spirv_codegen.h
@@ -353,10 +353,13 @@ class TaskCodegen : public IRVisitor {
   spirv::Value get_ad_stack_heap_buffer_int();
   spirv::Value get_ad_stack_heap_thread_base_int();
   spirv::Value ad_stack_heap_int_ptr(spirv::Value slot_offset, spirv::Value count);
-  // Metadata buffer accessors. Each emits one OpLoad on first use and caches the SSA id.
+  // Metadata buffer accessors. Each emits one OpLoad on first use and caches the SSA id. The two stride loads are
+  // seeded by `preload_ad_stack_metadata_strides` at the task entry block so the cached ids dominate every heap
+  // access site; see the comment on that function for why lazy first emission at a heap access site is unsound.
   spirv::Value get_ad_stack_metadata_buffer();
   spirv::Value get_ad_stack_metadata_stride_float();
   spirv::Value get_ad_stack_metadata_stride_int();
+  void preload_ad_stack_metadata_strides();
   void ensure_ad_stack_metadata_loaded(AdStackSpirv &info);
   // Lazy-allocate the per-task overflow-signal accumulator at the function entry block. See the member
   // doc on `any_overflow_signal_var_` for the design rationale.

--- a/quadrants/codegen/spirv/spirv_codegen.cpp
+++ b/quadrants/codegen/spirv/spirv_codegen.cpp
@@ -2080,6 +2080,7 @@ void TaskCodegen::generate_serial_kernel(OffloadedStmt *stmt) {
   // Initialise the adstack overflow-signal accumulator before any user code so the zero-init dominates
   // every push site and the task-end read. See `ensure_any_overflow_signal_var` doc for details.
   ensure_any_overflow_signal_var();
+  preload_ad_stack_metadata_strides();
   spirv::Value cond = ir_->eq(ir_->get_global_invocation_id(0),
                               ir_->uint_immediate_number(ir_->u32_type(), 0));  // if (gl_GlobalInvocationID.x > 0)
   spirv::Label then_label = ir_->new_label();
@@ -2134,6 +2135,7 @@ void TaskCodegen::generate_range_for_kernel(OffloadedStmt *stmt) {
 
   ir_->start_function(kernel_function_);
   ensure_any_overflow_signal_var();
+  preload_ad_stack_metadata_strides();
   const std::string total_elems_name("total_elems");
   spirv::Value total_elems;
   spirv::Value begin_expr_value;
@@ -2319,6 +2321,7 @@ void TaskCodegen::generate_struct_for_kernel(OffloadedStmt *stmt) {
   // we can do grid-strided loop.
   ir_->start_function(kernel_function_);
   ensure_any_overflow_signal_var();
+  preload_ad_stack_metadata_strides();
 
   auto listgen_buffer = get_buffer_value(BufferType::ListGen, PrimitiveType::u32);
   auto listgen_count_ptr = ir_->struct_array_access(ir_->u32_type(), listgen_buffer, ir_->const_i32_zero_);
@@ -2743,6 +2746,24 @@ spirv::Value TaskCodegen::get_ad_stack_metadata_stride_int() {
   return ad_stack_metadata_stride_int_;
 }
 
+// Seed the two memoized stride loads at the task entry block so the cached SSA ids dominate every adstack heap
+// access in the body. The getters above memoize the OpLoad emitted at their first call site; without this preload
+// the first f32 (or i32) heap access of the task can sit inside a conditional block - e.g. one arm of an `if`
+// whose sibling arm also hits the heap - and every access in a sibling block would then reuse an SSA id that does
+// not dominate it. `spirv-val` rejects such a module (SPIR-V section 2.16), and SPIRV-Cross silently emits the
+// reused id as a plain uninitialized MSL variable: the per-thread heap base `row_id * stride` collapses to
+// whatever the garbage register holds (typically 0), racing every thread of the dispatch onto the same heap row
+// and corrupting reverse-mode gradients on Metal. Gated on the pre-pass adstack count so tasks without adstacks
+// do not bind the AdStackMetadata buffer at all; tasks with adstacks always read it anyway, so the preload adds
+// no binding and at most one dead u32 load when only one of the two heaps is used.
+void TaskCodegen::preload_ad_stack_metadata_strides() {
+  if (num_ad_stacks_ == 0) {
+    return;
+  }
+  get_ad_stack_metadata_stride_float();
+  get_ad_stack_metadata_stride_int();
+}
+
 spirv::Value TaskCodegen::get_ad_stack_heap_thread_base_float() {
   // `row_id * per_thread_stride`. `row_id` is loaded fresh at every call from the Function-scope
   // `ad_stack_row_id_var_float_` (declared at the first alloca visit, written at the float Lowest Common Ancestor (LCA)
@@ -2822,11 +2843,11 @@ spirv::Value TaskCodegen::ad_stack_heap_int_ptr(spirv::Value slot_offset, spirv:
 
 // Lazily load the per-alloca `(offset, max_size)` pair for `info` from the AdStackMetadata buffer and cache the
 // SSA ids on `info`. The metadata buffer layout is `[stride_float, stride_int, offset_0, max_size_0, offset_1,
-// max_size_1, ...]` so slot i lives at buffer indices `2 + 2*i` and `2 + 2*i + 1`. First-call emission happens
-// at the first push / load-top / load-top-adj site for this alloca (the AllocaStmt visitor sets `stack_id` and
-// caches the buffer + stride eagerly so it dominates every sibling body). The adjoint offset for f32 adstacks
-// is a derived `OpIAdd` rather than an extra buffer load - mirrors the host launcher's `offset + max_size`
-// prefix-sum layout for the primal/adjoint pair.
+// max_size_1, ...]` so slot i lives at buffer indices `2 + 2*i` and `2 + 2*i + 1`. The AllocaStmt visitor calls
+// this eagerly at the alloca site so the OpLoads dominate every sibling push / load-top / load-top-adj body; the
+// two shared stride words are seeded even earlier, at the task entry block, by `preload_ad_stack_metadata_strides`.
+// The adjoint offset for f32 adstacks is a derived `OpIAdd` rather than an extra buffer load - mirrors the host
+// launcher's `offset + max_size` prefix-sum layout for the primal/adjoint pair.
 // Allocate the per-task overflow-signal accumulator at the function entry block and zero-initialize it.
 // Holds the maximum `stack_id + 1` value seen across all overflowing push sites in this thread; 0 means no
 // overflow. Read + conditionally atomic-max'd to the host-visible AdStackOverflow buffer at task-end.

--- a/tests/python/test_adstack.py
+++ b/tests/python/test_adstack.py
@@ -5324,3 +5324,48 @@ def test_adstack_offset_array_difference_loop_trip_grad_correct():
     for j in range(total):
         for e in range(n_env):
             assert grad[j, e] == pytest.approx(2.0 * x_np[j, e], rel=1e-5)
+
+
+@test_utils.test(require=qd.extension.adstack, ad_stack_experimental_enabled=True)
+def test_adstack_stride_load_dominates_sibling_branch_grad_distinct_per_thread():
+    # The reverse pass of a kernel whose first f32 adstack heap access sits inside one arm of a runtime `if` while
+    # the sibling arm also hits the heap must keep per-thread gradients distinct. The memoized per-thread stride
+    # load from the AdStackMetadata buffer is emitted at the task entry block so its SSA id dominates both arms;
+    # emitting it lazily at the first heap access would define it inside the first arm and reuse it from the
+    # sibling arm, which violates SPIR-V dominance and lands on Metal as an uninitialized stride register: every
+    # thread then computes the same heap row base and the whole dispatch races on one row, collapsing the per-env
+    # adjoints to a single value. The taken `else` arm below runs a field-bounded loop whose multiply spills the
+    # operand on the f32 heap; the compiled-but-untaken `if` arm reads both a reduction and a component of a
+    # vector, which is what places the first f32 heap access of the module inside that arm.
+    n_env = 2
+    dt = 0.01
+
+    jtype = qd.field(qd.i32, shape=())
+    q_end = qd.field(qd.i32, shape=())
+    qpos = qd.field(qd.f32, shape=(2, n_env), needs_grad=True)
+    vel = qd.field(qd.f32, shape=(2, n_env), needs_grad=True)
+
+    @qd.kernel
+    def compute():
+        for i_env in range(n_env):
+            if jtype[None] == 3:
+                rv = qd.Vector([vel[0, i_env], vel[1, i_env]], dt=qd.f32)
+                qpos[0, i_env] = rv.norm_sqr()
+                qpos[1, i_env] = rv[0]
+            else:
+                for j in range(q_end[None]):
+                    qpos[j, i_env] = vel[j, i_env] * dt
+
+    jtype[None] = 2
+    q_end[None] = 1
+    qpos.fill(0.0)
+    vel.fill(0.0)
+    vel.grad.fill(0.0)
+    seed = np.zeros((2, n_env), dtype=np.float32)
+    seed[0, :] = np.arange(1, n_env + 1, dtype=np.float32)
+    qpos.grad.from_numpy(seed)
+    compute.grad()
+
+    grad = vel.grad.to_numpy()[0]
+    for i in range(n_env):
+        assert grad[i] == pytest.approx((i + 1) * dt, rel=1e-6)


### PR DESCRIPTION
Issue: #805

The reverse-mode collapse reported in #805 is not an Apple compiler uniformity bug: `get_ad_stack_metadata_stride_(float|int)` memoize the stride OpLoad at their first call site, so when the first f32 heap access of a task sits inside one arm of a runtime `if`, every access in the sibling arm reuses an SSA id that does not dominate it. `spirv-val` rejects the module (section 2.16), but SPIRV-Cross does not validate and emits the reused id as a plain uninitialized MSL variable, so the per-thread heap base `row_id * stride` multiplies a correct per-lane `row_id` by a garbage stride (typically 0) and every thread of the dispatch races on the same heap row. The fix seeds both memoized stride loads at the task entry block (`preload_ad_stack_metadata_strides`, called from each `generate_*_kernel`, gated on the pre-pass adstack count so adstack-free tasks do not bind the metadata buffer).

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
