### PR TITLE
[Bug] Don't cache may-aliasing buffers in CacheLoopInvariantGlobalVars (#810)

### DIFF
--- a/quadrants/transforms/cache_loop_invariant_global_vars.cpp
+++ b/quadrants/transforms/cache_loop_invariant_global_vars.cpp
@@ -34,6 +34,88 @@ void gather_atomic_dests(IRNode *root,
   }
 }
 
+// Return the buffer that |ptr| addresses: a field by SNode (out_snode) or an
+// ndarray by arg_id (out_arr_id). Returns true if |ptr| resolves to either.
+bool resolve_access_buffer(Stmt *ptr, const SNode *&out_snode, std::vector<int> &out_arr_id) {
+  Stmt *origin = ptr;
+  if (auto *mptr = origin->cast<MatrixPtrStmt>()) {
+    origin = mptr->origin;
+  }
+  if (auto *gptr = origin->cast<GlobalPtrStmt>()) {
+    out_snode = gptr->snode;
+    return true;
+  }
+  if (auto *eptr = origin->cast<ExternalPtrStmt>()) {
+    if (auto *arg = eptr->base_ptr->cast<ArgLoadStmt>()) {
+      out_arr_id = arg->arg_id;
+      return true;
+    }
+  }
+  return false;
+}
+
+// Collect buffers accessed via a may-aliasing pair of distinct pointers, i.e.
+// two access pointers P1, P2 with alias_analysis(P1, P2) == uncertain. Such a
+// buffer must not be cached by this pass: the pass may cache one access into a
+// local slot and defer its write-back until after the loop, while an aliasing
+// access reads or writes global memory directly. When the two addresses coincide
+// at runtime the direct access observes a stale value (see issue #810). Buffers
+// whose accesses are all definitely-same or all definitely-different are safe and
+// are left cacheable, so read-modify-write accumulators and disjoint accesses are
+// unaffected. Field buffers are recorded by SNode; ndarray buffers by arg_id.
+void gather_may_alias_unsafe_buffers(IRNode *root,
+                                     std::unordered_set<const SNode *> &field_snodes,
+                                     std::unordered_set<std::vector<int>, hashing::Hasher<std::vector<int>>> &arr_ids) {
+  auto accesses = irpass::analysis::gather_statements(root, [](Stmt *s) {
+    return s->is<GlobalLoadStmt>() || s->is<GlobalStoreStmt>() || s->is<AtomicOpStmt>();
+  });
+  std::unordered_map<const SNode *, std::vector<Stmt *>> field_ptrs;
+  std::unordered_map<std::vector<int>, std::vector<Stmt *>, hashing::Hasher<std::vector<int>>> arr_ptrs;
+  for (auto *s : accesses) {
+    Stmt *ptr = nullptr;
+    if (auto *load = s->cast<GlobalLoadStmt>()) {
+      ptr = load->src;
+    } else if (auto *store = s->cast<GlobalStoreStmt>()) {
+      ptr = store->dest;
+    } else if (auto *atomic = s->cast<AtomicOpStmt>()) {
+      ptr = atomic->dest;
+    }
+    if (ptr == nullptr) {
+      continue;
+    }
+    const SNode *snode = nullptr;
+    std::vector<int> arr_id;
+    if (!resolve_access_buffer(ptr, snode, arr_id)) {
+      continue;
+    }
+    if (snode != nullptr) {
+      field_ptrs[snode].push_back(ptr);
+    } else {
+      arr_ptrs[arr_id].push_back(ptr);
+    }
+  }
+  auto has_may_alias_pair = [](const std::vector<Stmt *> &ptrs) {
+    for (int i = 0; i < (int)ptrs.size(); i++) {
+      for (int j = i + 1; j < (int)ptrs.size(); j++) {
+        if (irpass::analysis::alias_analysis(ptrs[i], ptrs[j]) == AliasResult::uncertain) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+  for (auto &[snode, ptrs] : field_ptrs) {
+    if (has_may_alias_pair(ptrs)) {
+      field_snodes.insert(snode);
+    }
+  }
+  for (auto &[arr_id, ptrs] : arr_ptrs) {
+    if (has_may_alias_pair(ptrs)) {
+      arr_ids.insert(arr_id);
+    }
+  }
+}
+
 }  // namespace
 
 class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
@@ -58,6 +140,8 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
   std::unordered_set<Stmt *> dynamic_indexed_ptrs_;
   std::unordered_set<const SNode *> atomic_dest_snodes_;
   std::unordered_set<std::vector<int>, hashing::Hasher<std::vector<int>>> atomic_dest_arr_ids_;
+  std::unordered_set<const SNode *> may_alias_unsafe_snodes_;
+  std::unordered_set<std::vector<int>, hashing::Hasher<std::vector<int>>> may_alias_unsafe_arr_ids_;
 
   OffloadedStmt *current_offloaded;
 
@@ -77,6 +161,9 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
     atomic_dest_snodes_.clear();
     atomic_dest_arr_ids_.clear();
     gather_atomic_dests(stmt, atomic_dest_snodes_, atomic_dest_arr_ids_);
+    may_alias_unsafe_snodes_.clear();
+    may_alias_unsafe_arr_ids_.clear();
+    gather_may_alias_unsafe_buffers(stmt, may_alias_unsafe_snodes_, may_alias_unsafe_arr_ids_);
 
     // We don't need to visit TLS/BLS prologues/epilogues.
     if (stmt->body) {
@@ -244,6 +331,18 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
     return false;
   }
 
+  bool is_may_alias_unsafe(Stmt *stmt) {
+    const SNode *snode = nullptr;
+    std::vector<int> arr_id;
+    if (!resolve_access_buffer(stmt, snode, arr_id)) {
+      return false;
+    }
+    if (snode != nullptr) {
+      return may_alias_unsafe_snodes_.count(snode) > 0;
+    }
+    return may_alias_unsafe_arr_ids_.count(arr_id) > 0;
+  }
+
   std::optional<int> find_cache_depth_if_cacheable(Stmt *operand, Block *current_scope) {
     if (is_dynamically_indexed(operand)) {
       return std::nullopt;
@@ -252,6 +351,9 @@ class CacheLoopInvariantGlobalVars : public LoopInvariantDetector {
       return std::nullopt;
     }
     if (is_atomic_dest(operand)) {
+      return std::nullopt;
+    }
+    if (is_may_alias_unsafe(operand)) {
       return std::nullopt;
     }
     std::optional<int> depth;

--- a/tests/python/test_cache_loop_invariant.py
+++ b/tests/python/test_cache_loop_invariant.py
@@ -59,3 +59,39 @@ def test_atomic_dest_not_cached(use_ndarray: bool) -> None:
     k(x, result)
     for i in range(n):
         assert result[i] == m, f"result[{i}] = {result[i]}, expected {m}"
+
+
+@pytest.mark.parametrize("use_ndarray", [False, True])
+@test_utils.test()
+def test_literal_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> None:
+    """Regression for issue #810: a literal-index load (a[0]) that may alias a
+    loop-variable-index store (a[i]) must not be served from a cached local slot
+    while the store's write-back is deferred past the loop.  Otherwise the load
+    returns a stale pre-write-back value when the two indices coincide (i == 0).
+
+    Requires all four ingredients: a serialized outer loop, an inner loop, a
+    store through the outer loop variable index, and a literal-index read of the
+    same buffer guarded by a comparison of the loop variable to that literal.
+    """
+    n = 2
+
+    TensorType = qd.ndarray if use_ndarray else qd.field
+
+    AnnotationType = qd.types.ndarray() if use_ndarray else qd.template()
+
+    @qd.kernel
+    def k(a: AnnotationType, out: AnnotationType):
+        qd.loop_config(serialize=True)
+        for i_c in range(n):
+            for i_iter in range(1):
+                a[i_c] = 1
+                if i_c == 0:
+                    out[0] = a[0]
+                    out[1] = a[i_c]
+
+    a = TensorType(dtype=qd.i32, shape=(n,))
+    out = TensorType(dtype=qd.i32, shape=(n,))
+
+    k(a, out)
+    assert out[0] == 1, f"stale literal-index read: out[0] = {out[0]}, expected 1"
+    assert out[1] == 1, f"out[1] = {out[1]}, expected 1"


### PR DESCRIPTION
CacheLoopInvariantGlobalVars could scalarize a loop-invariant global access into a local slot and defer its write-back until after the loop, while a distinct may-aliasing access to the same buffer read/wrote global memory directly. When the two addresses coincide at runtime (e.g. a store through a loop-variable index a[i] and a guarded literal-index read a[0] in a serialized loop) the direct access observed a stale value, so the in-kernel read returned the pre-write-back value even though post-kernel memory was correct.

The serial-offload path took an unconditional is_offload_unique()==true short-circuit, bypassing the may-alias exclusion the parallel path already gets via gather_uniquely_accessed_pointers.

Exclude from caching any buffer accessed within the offload through two distinct pointers P1, P2 with alias_analysis(P1, P2) == uncertain. Buffers whose accesses are all definitely-same or all definitely-different remain cacheable, so read-modify-write accumulators and disjoint accesses are unaffected.

Add a regression test (field + ndarray) reproducing the four ingredients: a serialized outer loop, an inner loop, a store through the outer loop variable index, and a guarded literal-index read of the same buffer.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
