### PR TITLE
[Bug] Exclude may-aliasing buffers from loop-invariant caching (#810)

### DIFF
--- a/quadrants/analysis/gather_dynamically_indexed_pointers.cpp
+++ b/quadrants/analysis/gather_dynamically_indexed_pointers.cpp
@@ -3,7 +3,10 @@
 #include "quadrants/ir/analysis.h"
 #include "quadrants/ir/statements.h"
 #include "quadrants/ir/visitors.h"
+#include "quadrants/util/hash.h"
 #include <algorithm>
+#include <unordered_map>
+#include <vector>
 
 namespace quadrants::lang {
 
@@ -56,8 +59,16 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
     if (!extern_ptr->base_ptr->is<ArgLoadStmt>()) {
       return;
     }
-    for (auto *other_extern_ptr : extern_ptrs_) {
-      if (other_extern_ptr == extern_ptr || !other_extern_ptr->base_ptr->is<ArgLoadStmt>()) {
+    // Only external pointers sharing the same arg_id can alias -- alias_analysis() returns 'different'
+    // for distinct arg_ids -- so consult just that bucket instead of scanning every external pointer.
+    // This keeps the guard identical while avoiding O(n^2) compile-time work on kernels with many
+    // disjoint accesses (e.g. statically unrolled kernels).
+    auto it = extern_ptrs_by_arg_.find(extern_ptr->base_ptr->as<ArgLoadStmt>()->arg_id);
+    if (it == extern_ptrs_by_arg_.end()) {
+      return;
+    }
+    for (auto *other_extern_ptr : it->second) {
+      if (other_extern_ptr == extern_ptr) {
         continue;
       }
       if (irpass::analysis::alias_analysis(extern_ptr, other_extern_ptr) == AliasResult::uncertain) {
@@ -68,7 +79,15 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
   }
 
   void record_may_alias_ptr(GlobalPtrStmt *global_ptr) {
-    for (auto *other_global_ptr : global_ptrs_) {
+    // Only global pointers on the same SNode can alias -- alias_analysis() returns 'different' for
+    // distinct SNodes -- so consult just that bucket instead of scanning every global pointer. This
+    // keeps the guard identical while avoiding O(n^2) compile-time work on kernels with many disjoint
+    // accesses (e.g. statically unrolled kernels).
+    auto it = global_ptrs_by_snode_.find(global_ptr->snode);
+    if (it == global_ptrs_by_snode_.end()) {
+      return;
+    }
+    for (auto *other_global_ptr : it->second) {
       if (other_global_ptr == global_ptr) {
         continue;
       }
@@ -91,7 +110,9 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
     }
     record_may_alias_ptr(stmt);
 
-    global_ptrs_.insert(stmt);
+    if (global_ptrs_.insert(stmt).second) {
+      global_ptrs_by_snode_[stmt->snode].push_back(stmt);
+    }
   }
 
   void visit(ExternalPtrStmt *stmt) override {
@@ -102,7 +123,9 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
     }
     record_may_alias_ptr(stmt);
 
-    extern_ptrs_.insert(stmt);
+    if (extern_ptrs_.insert(stmt).second && stmt->base_ptr->is<ArgLoadStmt>()) {
+      extern_ptrs_by_arg_[stmt->base_ptr->as<ArgLoadStmt>()->arg_id].push_back(stmt);
+    }
   }
 
   void visit(MatrixPtrStmt *stmt) override {
@@ -140,6 +163,12 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
   std::unordered_set<Stmt *> dynamically_indexed_ptrs_;
   std::unordered_set<GlobalPtrStmt *> global_ptrs_;
   std::unordered_set<ExternalPtrStmt *> extern_ptrs_;
+  // Buckets keyed by buffer for the may-alias comparison: only pointers to the same buffer (same
+  // external arg_id / same global SNode) can be 'uncertain' aliases, so record_may_alias_ptr()
+  // consults just its own bucket instead of every previously seen pointer.
+  std::unordered_map<std::vector<int>, std::vector<ExternalPtrStmt *>, hashing::Hasher<std::vector<int>>>
+      extern_ptrs_by_arg_;
+  std::unordered_map<SNode *, std::vector<GlobalPtrStmt *>> global_ptrs_by_snode_;
 };
 
 namespace irpass::analysis {

--- a/quadrants/analysis/gather_dynamically_indexed_pointers.cpp
+++ b/quadrants/analysis/gather_dynamically_indexed_pointers.cpp
@@ -43,6 +43,42 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
     }
   }
 
+  // A pointer that may alias (alias_analysis == uncertain) another access to the same buffer within
+  // this offload must not be cached: the loop-invariant caching pass can buffer one access into a
+  // local slot and defer its write-back past the loop, while the aliasing access reads/writes global
+  // memory directly, so when the two addresses coincide at runtime the direct access observes a stale
+  // value (issue #810). A serialized loop bypasses the parallel-loop uniqueness analysis that would
+  // otherwise reject such a pair, so both accesses are flagged here to keep them out of the caching
+  // pass. Accesses that are all definitely-same or all definitely-different are left cacheable, so
+  // read-modify-write accumulators (same address) and disjoint accesses (different address, e.g. a
+  // literal row a[0, i] and a[1, i]) remain cacheable.
+  void record_may_alias_ptr(ExternalPtrStmt *extern_ptr) {
+    if (!extern_ptr->base_ptr->is<ArgLoadStmt>()) {
+      return;
+    }
+    for (auto *other_extern_ptr : extern_ptrs_) {
+      if (other_extern_ptr == extern_ptr || !other_extern_ptr->base_ptr->is<ArgLoadStmt>()) {
+        continue;
+      }
+      if (irpass::analysis::alias_analysis(extern_ptr, other_extern_ptr) == AliasResult::uncertain) {
+        record_dynamic_indexed_ptr(extern_ptr);
+        return;
+      }
+    }
+  }
+
+  void record_may_alias_ptr(GlobalPtrStmt *global_ptr) {
+    for (auto *other_global_ptr : global_ptrs_) {
+      if (other_global_ptr == global_ptr) {
+        continue;
+      }
+      if (irpass::analysis::alias_analysis(global_ptr, other_global_ptr) == AliasResult::uncertain) {
+        record_dynamic_indexed_ptr(global_ptr);
+        return;
+      }
+    }
+  }
+
  public:
   explicit DynamicIndexingAnalyzer(IRNode *node) {
   }
@@ -53,6 +89,7 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
         record_dynamic_indexed_ptr(stmt);
       }
     }
+    record_may_alias_ptr(stmt);
 
     global_ptrs_.insert(stmt);
   }
@@ -63,6 +100,7 @@ class DynamicIndexingAnalyzer : public BasicStmtVisitor {
         record_dynamic_indexed_ptr(stmt);
       }
     }
+    record_may_alias_ptr(stmt);
 
     extern_ptrs_.insert(stmt);
   }

--- a/tests/python/test_cache_loop_invariant.py
+++ b/tests/python/test_cache_loop_invariant.py
@@ -174,3 +174,46 @@ def test_vector_element_aliasing_store_no_miscompile(use_ndarray: bool) -> None:
     res = out.to_numpy()
     assert res[0][0] == 1, f"vector-element stale read: out[0][0] = {res[0][0]}, expected 1"
     assert res[1][0] == 1, f"out[1][0] = {res[1][0]}, expected 1"
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#812 review: cross-parameter ndarray aliasing is not yet handled. When the same ndarray is "
+    "bound to two kernel parameters, the two ExternalPtrStmts have distinct ArgLoadStmt arg_ids, so "
+    "alias_analysis() returns 'different' (not 'uncertain') and the may-alias caching guard never fires "
+    "across the parameters. Deciding this needs launch-time aliasing knowledge (kernels are compiled "
+    "per-signature, not per-pointer), so it is out of scope for the same-parameter #810 fix.",
+)
+@test_utils.test(arch=qd.cpu)
+def test_cross_parameter_ndarray_aliasing_store_stale_read() -> None:
+    """Known gap (issue #810 / PR #812 review): the #810 hazard split across two ndarray parameters that
+    the caller binds to the SAME ndarray at launch.  The loop-variable-index store goes through one
+    parameter (a[i_c]) and the guarded literal-index load through the other (b[0]); both are the same
+    ndarray, so b[0] aliases a[i_c] when i_c == 0.
+
+    Because the two parameters have distinct arg_ids, alias_analysis(a[i_c], b[0]) is 'different' rather
+    than 'uncertain', the guard is skipped, and b[0] returns a stale pre-write-back value.  The
+    field/template variant of this (same field bound to two params) IS fixed, because both handles
+    resolve to the same SNode and alias_analysis() then reports 'uncertain'.
+
+    Marked xfail(strict): if a later change closes the ndarray gap this will XPASS and flag that the
+    guard and this test should be promoted to a real regression assertion.
+    """
+    n = 2
+
+    @qd.kernel
+    def k(a: qd.types.ndarray(), b: qd.types.ndarray(), out: qd.types.ndarray()):
+        qd.loop_config(serialize=True)
+        for i_c in range(n):
+            for i_iter in range(1):
+                a[i_c] = 1
+                if i_c == 0:
+                    out[0] = b[0]
+                    out[1] = a[i_c]
+
+    a = qd.ndarray(dtype=qd.i32, shape=(n,))
+    out = qd.ndarray(dtype=qd.i32, shape=(n,))
+
+    k(a, a, out)  # same ndarray bound to both parameters -> b aliases a at launch
+    assert out[0] == 1, f"stale cross-parameter read: out[0] = {out[0]}, expected 1"
+    assert out[1] == 1, f"out[1] = {out[1]}, expected 1"

--- a/tests/python/test_cache_loop_invariant.py
+++ b/tests/python/test_cache_loop_invariant.py
@@ -133,16 +133,20 @@ def test_loop_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> No
 
 @pytest.mark.parametrize("use_ndarray", [False, True])
 @test_utils.test()
-def test_vector_element_literal_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> None:
-    """Regression for issue #810 through vector/matrix *elements* (TensorType), the case raised in the
-    PR #811 review.
+def test_vector_element_aliasing_store_no_miscompile(use_ndarray: bool) -> None:
+    """Guard test for the vector/matrix *element* variant of issue #810, raised in the PR #811 review.
 
-    Here both aliasing accesses reach the caching pass as MatrixPtrStmts over ExternalPtr/GlobalPtr
-    origins (a[i_c][0] store vs guarded a[0][0] read).  alias_analysis() returns 'different' (not
-    'uncertain') for two MatrixPtrStmts whose origins are only 'uncertain' aliases, so a guard that
-    queries alias_analysis on the loaded/stored MatrixPtr pointers directly misses the hazard.  The fix
-    keys on the ExternalPtr/GlobalPtr origins (where alias_analysis is 'uncertain') and the cache pass
-    resolves each MatrixPtr to that origin, so the element accesses stay out of the caching pass.
+    The concern: when the aliasing accesses are vector/matrix elements they reach the caching pass as
+    MatrixPtrStmts over ExternalPtr/GlobalPtr origins (a[i_c][0] store vs guarded a[0][0] read), and
+    alias_analysis() returns 'different' (not 'uncertain') for two MatrixPtrStmts whose origins are only
+    'uncertain' aliases -- so a guard keyed on the loaded/stored MatrixPtr pointers could miss the
+    hazard.
+
+    Empirically (x64) this pattern is NOT miscompiled on either baseline main or the fix: across
+    ndarray-vector, field-vector, matrix-field, and two-loop-index variants the matrix-element caching
+    path never defers the write-back the way the scalar path does, so no stale read occurs regardless of
+    the may-alias guard.  This test does not distinguish the fix; it guards against a future change that
+    would start hoisting matrix-element accesses and reintroduce the hazard.
     """
     n = 2
     k = 2
@@ -168,5 +172,5 @@ def test_vector_element_literal_index_load_not_cached_over_aliasing_store(use_nd
 
     kern(a, out)
     res = out.to_numpy()
-    assert res[0][0] == 1, f"stale literal-index vector-element read: out[0][0] = {res[0][0]}, expected 1"
+    assert res[0][0] == 1, f"vector-element stale read: out[0][0] = {res[0][0]}, expected 1"
     assert res[1][0] == 1, f"out[1][0] = {res[1][0]}, expected 1"

--- a/tests/python/test_cache_loop_invariant.py
+++ b/tests/python/test_cache_loop_invariant.py
@@ -129,3 +129,44 @@ def test_loop_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> No
     k(a, out)
     assert out[0] == 1, f"stale loop-index read: out[0] = {out[0]}, expected 1"
     assert out[1] == 1, f"stale loop-index read: out[1] = {out[1]}, expected 1"
+
+
+@pytest.mark.parametrize("use_ndarray", [False, True])
+@test_utils.test()
+def test_vector_element_literal_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> None:
+    """Regression for issue #810 through vector/matrix *elements* (TensorType), the case raised in the
+    PR #811 review.
+
+    Here both aliasing accesses reach the caching pass as MatrixPtrStmts over ExternalPtr/GlobalPtr
+    origins (a[i_c][0] store vs guarded a[0][0] read).  alias_analysis() returns 'different' (not
+    'uncertain') for two MatrixPtrStmts whose origins are only 'uncertain' aliases, so a guard that
+    queries alias_analysis on the loaded/stored MatrixPtr pointers directly misses the hazard.  The fix
+    keys on the ExternalPtr/GlobalPtr origins (where alias_analysis is 'uncertain') and the cache pass
+    resolves each MatrixPtr to that origin, so the element accesses stay out of the caching pass.
+    """
+    n = 2
+    k = 2
+
+    if use_ndarray:
+        a = qd.Vector.ndarray(k, qd.i32, shape=(n,))
+        out = qd.Vector.ndarray(k, qd.i32, shape=(n,))
+        AnnotationType = qd.types.ndarray(ndim=1)
+    else:
+        a = qd.Vector.field(k, qd.i32, shape=(n,))
+        out = qd.Vector.field(k, qd.i32, shape=(n,))
+        AnnotationType = qd.template()
+
+    @qd.kernel
+    def kern(a: AnnotationType, out: AnnotationType):
+        qd.loop_config(serialize=True)
+        for i_c in range(n):
+            for i_iter in range(1):
+                a[i_c][0] = 1
+                if i_c == 0:
+                    out[0][0] = a[0][0]
+                    out[1][0] = a[i_c][0]
+
+    kern(a, out)
+    res = out.to_numpy()
+    assert res[0][0] == 1, f"stale literal-index vector-element read: out[0][0] = {res[0][0]}, expected 1"
+    assert res[1][0] == 1, f"out[1][0] = {res[1][0]}, expected 1"

--- a/tests/python/test_cache_loop_invariant.py
+++ b/tests/python/test_cache_loop_invariant.py
@@ -59,3 +59,73 @@ def test_atomic_dest_not_cached(use_ndarray: bool) -> None:
     k(x, result)
     for i in range(n):
         assert result[i] == m, f"result[{i}] = {result[i]}, expected {m}"
+
+
+@pytest.mark.parametrize("use_ndarray", [False, True])
+@test_utils.test()
+def test_literal_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> None:
+    """Regression for issue #810: a literal-index load (a[0]) that may alias a loop-variable-index
+    store (a[i]) must not be served from a cached local slot while the store's write-back is deferred
+    past the loop.  When the two indices coincide (i == 0) the literal-index read otherwise returns a
+    stale pre-write-back value.
+
+    Requires all four ingredients: a serialized outer loop, an inner loop, a store through the outer
+    loop variable index, and a literal-index read of the same buffer guarded by a comparison of the
+    loop variable to that literal.
+    """
+    n = 2
+
+    TensorType = qd.ndarray if use_ndarray else qd.field
+
+    AnnotationType = qd.types.ndarray() if use_ndarray else qd.template()
+
+    @qd.kernel
+    def k(a: AnnotationType, out: AnnotationType):
+        qd.loop_config(serialize=True)
+        for i_c in range(n):
+            for i_iter in range(1):
+                a[i_c] = 1
+                if i_c == 0:
+                    out[0] = a[0]
+                    out[1] = a[i_c]
+
+    a = TensorType(dtype=qd.i32, shape=(n,))
+    out = TensorType(dtype=qd.i32, shape=(n,))
+
+    k(a, out)
+    assert out[0] == 1, f"stale literal-index read: out[0] = {out[0]}, expected 1"
+    assert out[1] == 1, f"out[1] = {out[1]}, expected 1"
+
+
+@pytest.mark.parametrize("use_ndarray", [False, True])
+@test_utils.test()
+def test_loop_index_load_not_cached_over_aliasing_store(use_ndarray: bool) -> None:
+    """Regression for the same hazard as #810 but through two DISTINCT loop-variable indices instead of
+    a literal.  A store through one loop index (a[i_c]) and a guarded read through another loop index
+    (a[t]) may alias when i_c == t, so the buffer must not be cached.
+
+    A structural const-vs-loop-index guard misses this because both accesses are loop-indexed; an
+    alias-analysis guard catches it because alias_analysis(a[i_c], a[t]) is 'uncertain'.
+    """
+    n = 2
+
+    TensorType = qd.ndarray if use_ndarray else qd.field
+
+    AnnotationType = qd.types.ndarray() if use_ndarray else qd.template()
+
+    @qd.kernel
+    def k(a: AnnotationType, out: AnnotationType):
+        qd.loop_config(serialize=True)
+        for t in range(n):
+            for i_c in range(n):
+                for i_iter in range(1):
+                    a[i_c] = 1
+                    if i_c == t:
+                        out[t] = a[t]
+
+    a = TensorType(dtype=qd.i32, shape=(n,))
+    out = TensorType(dtype=qd.i32, shape=(n,))
+
+    k(a, out)
+    assert out[0] == 1, f"stale loop-index read: out[0] = {out[0]}, expected 1"
+    assert out[1] == 1, f"stale loop-index read: out[1] = {out[1]}, expected 1"


### PR DESCRIPTION
CacheLoopInvariantGlobalVars could scalarize a loop-invariant global access into a local slot and defer its write-back until after the loop, while a distinct may-aliasing access to the same buffer read/wrote global memory directly. When the two addresses coincide at runtime (e.g. a store through a loop-variable index a[i] and a guarded read a[0] or a[t] in a serialized loop) the direct access observed a stale value, so the in-kernel read returned the pre-write-back value even though post-kernel memory was correct.

The pass consults gather_dynamically_indexed_pointers as its aliasing guard, but that analysis only flagged pointers with a non-const/non-loop index, and treated a const-indexed and a loop-index access as independently safe, so their mutual aliasing was never recorded. The serial-offload path relies on this guard because is_offload_unique() short-circuits to true for serial tasks, bypassing the uniqueness analysis the parallel path uses.

Flag a buffer's access pointer as non-cacheable when it may alias another access to the same buffer, decided by alias_analysis(P1, P2) == uncertain. Accesses that are all definitely-same or all definitely-different remain cacheable, so read-modify-write accumulators and disjoint accesses (e.g. a[0, i] and a[1, i]) are unaffected. Using the alias oracle rather than an index-kind heuristic also catches two distinct loop indices (a[i] vs a[t]) that a structural const-vs-loop guard would miss.

Add regression tests (field + ndarray) for both the literal-index and the loop-index aliasing patterns.

Note: this version of the code is strongly based on code from @duburcqa 

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
