### PR TITLE
[CI] Split Mac tests into per-backend jobs (metal/vulkan/cpu)

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -54,14 +54,27 @@ jobs:
   test:
     needs: build_mac
     name: Test on Mac
+    # Split the previously-combined `--arch metal,vulkan,cpu` run into one job per backend
+    # (see MAC_TEST_ARCH in 4_test.sh). Each job then carries only ~1/3 of the suite, which
+    # keeps a single runner from being oversubscribed during test teardown - the cause of
+    # the recent Mac CI timeouts - and lets the three backends run in parallel. The build
+    # is unchanged (one wheel per Python version, shared by all three legs).
     strategy:
       fail-fast: false
       matrix:
         MAC_OS_VERSION: [26]
         PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
+        ARCH: [metal, vulkan, cpu]
         include:
           - MAC_OS_VERSION: 15
             PYTHON_VERSION: '3.10'
+            ARCH: metal
+          - MAC_OS_VERSION: 15
+            PYTHON_VERSION: '3.10'
+            ARCH: vulkan
+          - MAC_OS_VERSION: 15
+            PYTHON_VERSION: '3.10'
+            ARCH: cpu
     runs-on: macos-${{ matrix.MAC_OS_VERSION }}
     steps:
       - uses: actions/checkout@v4
@@ -88,6 +101,8 @@ jobs:
         run: |
           bash .github/workflows/scripts_new/macosx/3_install.sh
       - name: Mac OS X test
+        env:
+          MAC_TEST_ARCH: ${{ matrix.ARCH }}
         run: |
           bash .github/workflows/scripts_new/macosx/4_test.sh
   publish_pypi:

--- a/.github/workflows/scripts_new/macosx/4_test.sh
+++ b/.github/workflows/scripts_new/macosx/4_test.sh
@@ -5,20 +5,32 @@ set -ex
 export QD_FILE_TIMING=1
 export QD_FILE_TIMING_OUTPUT="${RUNNER_TEMP}/file_timing.md"
 
+# Which backend(s) this job tests. The CI matrix runs one job per backend (metal / vulkan
+# / cpu) in parallel so each job carries ~1/3 of the suite; a single combined run pins all
+# three backends onto one runner and is far more prone to the teardown-time run-queue
+# oversubscription that has been timing Mac CI out. Defaults to all three when unset (e.g.
+# local runs). NB: deliberately NOT named QD_ARCH - that is a reserved quadrants env var
+# that overrides qd.init()'s arch via arch_from_name(), which aborts on the alias "cpu".
+MAC_TEST_ARCH="${MAC_TEST_ARCH:-metal,vulkan,cpu}"
+
 pip install --prefer-binary --group test
 find . -name '*.bc'
 ls -lh build/
 export QD_LIB_DIR="$(python -c 'import quadrants as qd; print(qd.__path__[0])' | tail -n 1)/_lib/runtime"
-chmod +x ./build/quadrants_cpp_tests
-./build/quadrants_cpp_tests
+# The C++ tests are backend-agnostic; run them once (on the cpu leg, or on the combined
+# default) rather than redundantly on every per-backend leg.
+if [ "${MAC_TEST_ARCH}" = "cpu" ] || [ "${MAC_TEST_ARCH}" = "metal,vulkan,cpu" ]; then
+  chmod +x ./build/quadrants_cpp_tests
+  ./build/quadrants_cpp_tests
+fi
 
 # Phase 1: run all tests except torch-dependent ones
-python tests/run_tests.py -v -r 1 --arch metal,vulkan,cpu -m "not needs_torch"
+python tests/run_tests.py -v -r 1 --arch "${MAC_TEST_ARCH}" -m "not needs_torch"
 
 # Phase 2: install torch, run only torch tests
 # TODO: revert to stable torch after 2.9.2 release
 pip install --pre --upgrade torch --index-url https://download.pytorch.org/whl/nightly/cpu
-python tests/run_tests.py -v -r 1 --arch metal,vulkan,cpu -m needs_torch
+python tests/run_tests.py -v -r 1 --arch "${MAC_TEST_ARCH}" -m needs_torch
 
 if [ -f "$QD_FILE_TIMING_OUTPUT" ]; then
   cat "$QD_FILE_TIMING_OUTPUT" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Problem
The Mac `test` job runs all three backends in one process (`--arch metal,vulkan,cpu`) on a single runner. Pinning the whole suite onto one 3-core `macos-26` runner oversubscribes the CPU run queue during **test teardown**, which is what has been making Mac CI slow to a crawl and time out (durations jumping from ~50 min to 150-350 min). The slow phase is entirely teardown-bound run-queue contention, and it scales with how much work is packed onto one runner.

## Change
Split the `test` job into **one parallel job per backend** via a `MAC_TEST_ARCH` matrix dimension:

- Each leg carries only ~1/3 of the suite, so it is far less likely to cross the teardown-oversubscription threshold.
- A bad runner only affects its own third instead of the whole run.
- The three backends run **concurrently**, so wall-clock is bounded by the slowest single-backend leg.
- **Build is unchanged** - one wheel per Python version, shared by all three test legs (this splits testing, not building).
- C++ tests run **once** (on the cpu leg) rather than redundantly on all three legs.

`MAC_TEST_ARCH` defaults to `metal,vulkan,cpu` when unset, so local/manual runs behave exactly as before. It is deliberately **not** named `QD_ARCH`, which quadrants treats as a reserved arch-override env var (`arch_from_name()` aborts on the alias `cpu`).

## Notes
- Diagnostic background: separate within-VM experiments confirm the collapse is environmental/run-queue-driven (arch-independent; a single-backend leg on a bad VM can still collapse), and that reducing per-runner load is the most reliable mitigation available on the free `macos-26` runners. This PR is that mitigation.

## Test plan
- [ ] All 15 Mac test legs (4 Python x 3 backends on macos-26, plus macos-15/3.10 x 3) go green.
- [ ] Per-leg wall time is materially lower than the old combined job.
- [ ] C++ tests execute exactly once (cpu leg).

Made with [Cursor](https://cursor.com)