### PR TITLE
[CI] Recycle the vulkan Mac test worker to bound MoltenVK state accumulation

### DIFF
--- a/.github/workflows/scripts_new/macosx/4_test.sh
+++ b/.github/workflows/scripts_new/macosx/4_test.sh
@@ -13,6 +13,20 @@ export QD_FILE_TIMING_OUTPUT="${RUNNER_TEMP}/file_timing.md"
 # that overrides qd.init()'s arch via arch_from_name(), which aborts on the alias "cpu".
 MAC_TEST_ARCH="${MAC_TEST_ARCH:-metal,vulkan,cpu}"
 
+# The vulkan (MoltenVK) leg accumulates GPU/driver state across the suite: VulkanStream::submit keeps
+# every submitted command buffer + fence until a wait_idle and MoltenVK's per-VkDevice Metal state grows
+# with it, until GfxRuntime::flush() can no longer create a command list and its QD_ASSERT aborts the
+# process during a qd.reset() teardown (Abort trap: 6 around ~63% of the suite). A process restart is the
+# only reset for this process-global Metal state, so we run the vulkan leg as a SINGLE xdist worker
+# (QD_WORKER_RECYCLE_EVERY forces one even at -t 1) recycled every N completed tests, which bounds the
+# accumulation. Validated on macos-26: 2978 passed / 0 failed in ~36 min vs a hard abort without it. The
+# metal (native Metal) and cpu (LLVM) legs don't hit this, so they run unchanged.
+RECYCLE_ARGS=()
+if [ "${MAC_TEST_ARCH}" = "vulkan" ]; then
+  export QD_WORKER_RECYCLE_EVERY=25
+  RECYCLE_ARGS=(-t 1)
+fi
+
 pip install --prefer-binary --group test
 find . -name '*.bc'
 ls -lh build/
@@ -25,12 +39,12 @@ if [ "${MAC_TEST_ARCH}" = "cpu" ] || [ "${MAC_TEST_ARCH}" = "metal,vulkan,cpu" ]
 fi
 
 # Phase 1: run all tests except torch-dependent ones
-python tests/run_tests.py -v -r 1 --arch "${MAC_TEST_ARCH}" -m "not needs_torch"
+python tests/run_tests.py -v -r 1 --arch "${MAC_TEST_ARCH}" -m "not needs_torch" "${RECYCLE_ARGS[@]}"
 
 # Phase 2: install torch, run only torch tests
 # TODO: revert to stable torch after 2.9.2 release
 pip install --pre --upgrade torch --index-url https://download.pytorch.org/whl/nightly/cpu
-python tests/run_tests.py -v -r 1 --arch "${MAC_TEST_ARCH}" -m needs_torch
+python tests/run_tests.py -v -r 1 --arch "${MAC_TEST_ARCH}" -m needs_torch "${RECYCLE_ARGS[@]}"
 
 if [ -f "$QD_FILE_TIMING_OUTPUT" ]; then
   cat "$QD_FILE_TIMING_OUTPUT" >> "$GITHUB_STEP_SUMMARY"

--- a/tests/python/conftest.py
+++ b/tests/python/conftest.py
@@ -156,29 +156,59 @@ def pytest_unconfigure(config):
     os.environ.pop("_QD_XDIST_EXIT_MARKER_DIR", None)
 
 
-@pytest.hookimpl(trylast=True)
-def pytest_runtest_logreport(report):
-    """Kill the xdist worker process after a test failure so it restarts with clean GPU state.
+def _qd_recycle_worker(nodeid):
+    """Write the intentional-exit marker and ``os._exit(1)`` so xdist restarts this worker clean.
 
-    Runs trylast so xdist's own hook sends the real test report over the channel first.  Before exiting, we write a
-    marker file so the controller's pytest_handlecrashitem can distinguish this intentional exit from a genuine crash
-    (segfault, OOM, etc.).
+    The controller's ``pytest_handlecrashitem`` uses the marker to tell this deliberate exit apart from a genuine
+    crash. Never returns.
     """
-    if not os.environ.get("PYTEST_XDIST_WORKER"):
-        return
-
-    if report.outcome not in ("error", "failed"):
-        return
-
     d = _exit_marker_dir()
     if d:
         worker_id = os.environ["PYTEST_XDIST_WORKER"]
         try:
             with open(os.path.join(d, worker_id), "w") as f:
-                f.write(report.nodeid)
+                f.write(nodeid)
         except OSError:
             pass
     os._exit(1)
+
+
+# Per-worker count of completed tests since this process last (re)started; used by the proactive recycle below.
+_qd_tests_since_recycle = 0
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_logreport(report):
+    """Kill the xdist worker process so it restarts with clean GPU state.
+
+    Two triggers, both requiring a live xdist worker:
+
+    * After a test failure -- resets any GPU state a failing kernel left behind.
+    * Proactively every ``QD_WORKER_RECYCLE_EVERY`` completed tests (opt-in; unset/0 disables). This bounds
+      driver-state accumulation that otherwise grows across the suite: ``VulkanStream::submit`` keeps every submitted
+      command buffer + fence in ``submitted_cmdbuffers_`` until a ``wait_idle``, and MoltenVK's encoder state grows with
+      it, until ``GfxRuntime::flush()`` can no longer create a command list and its ``QD_ASSERT`` aborts the process
+      during a ``qd.reset()`` teardown. Recycling a fresh process every N tests caps that growth, so the vulkan leg no
+      longer hard-aborts at ``-t 1`` (and stops slowly starving the runner at ``-t 2``).
+
+    Runs trylast so xdist's own hook ships the real report over the channel before we exit.
+    """
+    if not os.environ.get("PYTEST_XDIST_WORKER"):
+        return
+
+    if report.outcome in ("error", "failed"):
+        _qd_recycle_worker(report.nodeid)  # never returns
+
+    # Count one completed test on its teardown report, then recycle if we hit the (opt-in) cap.
+    if report.when == "teardown":
+        global _qd_tests_since_recycle
+        _qd_tests_since_recycle += 1
+        try:
+            every = int(os.environ.get("QD_WORKER_RECYCLE_EVERY", "0") or "0")
+        except ValueError:
+            every = 0
+        if every > 0 and _qd_tests_since_recycle >= every:
+            _qd_recycle_worker(report.nodeid)  # never returns
 
 
 def pytest_handlecrashitem(crashitem, report, sched):

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -102,10 +102,17 @@ def _test_python(args, default_dir="python"):
         pytest_args += ["-s"]
         print(f"Due to how pytest-xdist is implemented, the -s option does not work with multiple thread...")
     else:
-        if int(threads) > 1:
-            # We intentionally kill workers on test failure (see conftest.py) to reset GPU state.  Stock xdist counts
-            # each kill toward --max-worker-restart and shuts down the session when the cap is reached, so we set a
-            # very high cap to prevent that.
+        # We intentionally kill workers on test failure (see conftest.py) to reset GPU state.  Stock xdist counts
+        # each kill toward --max-worker-restart and shuts down the session when the cap is reached, so we set a
+        # very high cap to prevent that.  We normally only bother with xdist for threads>1, but when
+        # QD_WORKER_RECYCLE_EVERY is set we force a single worker even at threads==1 so the proactive-recycle hook
+        # (which needs a live xdist worker to os._exit) has a process to restart -- this is what makes a serial (-t 1)
+        # vulkan run survivable instead of hard-aborting once MoltenVK state accumulates.
+        try:
+            recycle_on = int(os.environ.get("QD_WORKER_RECYCLE_EVERY", "0") or "0") > 0
+        except ValueError:
+            recycle_on = False
+        if int(threads) > 1 or recycle_on:
             pytest_args += [
                 "-n",
                 str(threads),


### PR DESCRIPTION
## Summary

Fixes the Mac CI timeouts / hard aborts on the **vulkan** test leg (introduced by the teardown-time regression tracked since ~Jul 21). The vulkan (MoltenVK) leg accumulates **process-global** GPU/driver state across the suite: `VulkanStream::submit` retains every submitted command buffer + fence until a `wait_idle`, and MoltenVK's per-`VkDevice` Metal state grows with it, until `GfxRuntime::flush()` can no longer create a command list and its `QD_ASSERT` aborts the process during a `qd.reset()` teardown (`Abort trap: 6` around ~63% of the suite at `-t 1`; slow runner starvation / timeouts at higher `-t`).

The leak is process-global Metal/IOAccelerator state, so **a process restart is the only reset** -- recreating the `VkInstance`/`VkDevice` does not clear it (verified separately). The fix runs the vulkan leg as a **single xdist worker recycled every 25 completed tests**, which bounds the accumulation.

## Changes
- `tests/python/conftest.py`: extend the existing failure-kill worker hook with a **count-based proactive recycle** gated on `QD_WORKER_RECYCLE_EVERY` (unset/0 = disabled, so behaviour is unchanged everywhere else).
- `tests/run_tests.py`: when `QD_WORKER_RECYCLE_EVERY` is set, force a single xdist worker even at `-t 1` (the recycle hook needs a live worker process to restart).
- `.github/workflows/scripts_new/macosx/4_test.sh`: on the **vulkan** leg only, `export QD_WORKER_RECYCLE_EVERY=25` and run with `-t 1`. `metal` and `cpu` legs are untouched.

## Validation
- macos-26 vulkan full suite (`-m "not needs_torch"`): **2978 passed / 0 failed in ~36 min** with recycling, vs a hard `Abort trap: 6` at ~63% without it.
- No behaviour change for metal/cpu legs or for any non-Mac CI (env var unset elsewhere).

## Notes / follow-ups
- `-t 2 + recycle` (~20 min) is a plausible future speed optimization but was not end-to-end validated; this PR ships the conservatively-validated `-t 1 + recycle=25` config.
- Root-cause detail (why no VkInstance/VkDevice recreation and no in-process teardown fix works) is documented in the investigation notes.

Made with [Cursor](https://cursor.com)