### PR TITLE
[DONOTMERGE] Darwin non-VMA gtmp/listgen MoltenVK hang experiment

### DIFF
--- a/.github/workflows/macosx.yml
+++ b/.github/workflows/macosx.yml
@@ -1,126 +1,56 @@
 name: Mac OS
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-  workflow_dispatch:
-  release:
-    types: [published]
+    types: [opened, reopened, synchronize]
+  workflow_dispatch: {}
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'release' }}
+  cancel-in-progress: true
 jobs:
-  build_mac:
+  # [DONOTMERGE] Experiment: Darwin bypass_pooled_allocator for gtmp+listgen (plain vkAllocateMemory).
+  # Build one wheel, run bare qd.init(vulkan)/qd.reset() to 5000 cycles. Baseline hangs ~2900.
+  plain_gtmp_probe:
+    name: Plain gtmp/listgen bare probe
     strategy:
       fail-fast: false
       matrix:
         MAC_OS_VERSION: [26]
-        PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
-    name: Mac OS Build
+        PYTHON_VERSION: ['3.12']
     runs-on: macos-${{ matrix.MAC_OS_VERSION }}
+    timeout-minutes: 180
+    permissions:
+      contents: read
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
-          # Need full history + tags so setuptools_scm derives the correct wheel version
-          # (otherwise it falls back to "0.1"). Matches linux.yml / manylinux_wheel.yml.
           fetch-depth: 0
       - name: Python check
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.PYTHON_VERSION}}
-      - name: Set Python CP version
-        id: set_cp_version
-        run: |
-          pip install packaging
-          cp=$(python -c "from packaging import tags; print(next(tags.sys_tags()).interpreter)")
-          echo "PYTHON_CP_VERSION=${cp}"
-          echo "PYTHON_CP_VERSION=${cp}" >> $GITHUB_OUTPUT
+          python-version: ${{ matrix.PYTHON_VERSION }}
       - name: Mac OS X prerequisites
-        run: |
-          bash .github/workflows/scripts_new/macosx/1_prerequisites.sh
+        run: bash .github/workflows/scripts_new/macosx/1_prerequisites.sh
       - name: Mac OS X build
+        run: bash .github/workflows/scripts_new/macosx/2_build.sh
+      - name: Install wheel
         run: |
-          bash .github/workflows/scripts_new/macosx/2_build.sh
-      - uses: actions/upload-artifact@v4
+          pip install -U pip
+          pip install dist/*.whl
+          python -c "import quadrants as qd; print('quadrants', getattr(qd,'__version__','?'))"
+      - name: Bare init/reset probe (5000 cycles)
+        run: bash .github/workflows/scripts_new/macosx/plain_gtmp_probe.sh
+      - name: Upload probe log
+        if: always()
+        uses: actions/upload-artifact@v4
         with:
-          name: mac_wheel_${{ matrix.MAC_OS_VERSION }}_${{ steps.set_cp_version.outputs.PYTHON_CP_VERSION }}
+          name: plain_gtmp_probe_${{ matrix.MAC_OS_VERSION }}_${{ matrix.PYTHON_VERSION }}
+          path: ${{ runner.temp }}/plain_gtmp_out
+          if-no-files-found: warn
+      - name: Upload wheel
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: plain_gtmp_wheel_${{ matrix.MAC_OS_VERSION }}_${{ matrix.PYTHON_VERSION }}
           path: dist/*.whl
-      - uses: actions/upload-artifact@v4
-        with:
-          name: mac_cpptests_${{ matrix.MAC_OS_VERSION }}_${{ steps.set_cp_version.outputs.PYTHON_CP_VERSION }}
-          path: build/quadrants_cpp_tests
-  test:
-    needs: build_mac
-    name: Test on Mac
-    # Split the previously-combined `--arch metal,vulkan,cpu` run into one job per backend
-    # (see MAC_TEST_ARCH in 4_test.sh). Each job then carries only ~1/3 of the suite, which
-    # keeps a single runner from being oversubscribed during test teardown - the cause of
-    # the recent Mac CI timeouts - and lets the three backends run in parallel. The build
-    # is unchanged (one wheel per Python version, shared by all three legs).
-    strategy:
-      fail-fast: false
-      matrix:
-        MAC_OS_VERSION: [26]
-        PYTHON_VERSION: ['3.10', '3.11', '3.12', '3.13']
-        ARCH: [metal, vulkan, cpu]
-        include:
-          - MAC_OS_VERSION: 15
-            PYTHON_VERSION: '3.10'
-            ARCH: metal
-          - MAC_OS_VERSION: 15
-            PYTHON_VERSION: '3.10'
-            ARCH: vulkan
-          - MAC_OS_VERSION: 15
-            PYTHON_VERSION: '3.10'
-            ARCH: cpu
-    runs-on: macos-${{ matrix.MAC_OS_VERSION }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Python check
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.PYTHON_VERSION}}
-      - name: Set Python CP version
-        id: set_cp_version
-        run: |
-          pip install packaging
-          cp=$(python -c "from packaging import tags; print(next(tags.sys_tags()).interpreter)")
-          echo "PYTHON_CP_VERSION=${cp}"
-          echo "PYTHON_CP_VERSION=${cp}" >> $GITHUB_OUTPUT
-      - uses: actions/download-artifact@v4
-        with:
-          name: mac_wheel_26_${{ steps.set_cp_version.outputs.PYTHON_CP_VERSION }}
-          path: dist
-      - uses: actions/download-artifact@v4
-        with:
-          name: mac_cpptests_26_${{ steps.set_cp_version.outputs.PYTHON_CP_VERSION }}
-          path: build
-      - name: Mac OS X install
-        run: |
-          bash .github/workflows/scripts_new/macosx/3_install.sh
-      - name: Mac OS X test
-        env:
-          MAC_TEST_ARCH: ${{ matrix.ARCH }}
-        run: |
-          bash .github/workflows/scripts_new/macosx/4_test.sh
-  publish_pypi:
-    uses: ./.github/workflows/publish_pypi.yml
-    if: github.event_name == 'release'
-    needs: test
-    permissions:
-      id-token: write
-      contents: read
-    concurrency:
-      # group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.PYTHON_CP_VERSION }}-${{ matrix.PYTHON_CP_VERSION != 'cp310' && 'all' || github.sha }}-test
-      group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}-${{ matrix.PYTHON_CP_VERSION }}-test
-      cancel-in-progress: true
-    strategy:
-      matrix:
-        PYTHON_CP_VERSION: ["cp310", "cp311", "cp312", "cp313"]
-        MAC_OS_VERSION: [26]
-      fail-fast: false
-    with:
-      artifact_name: mac_wheel_${{ matrix.MAC_OS_VERSION }}_${{ matrix.PYTHON_CP_VERSION }}
-    secrets: inherit
+          if-no-files-found: warn

--- a/.github/workflows/scripts_new/macosx/plain_gtmp_probe.sh
+++ b/.github/workflows/scripts_new/macosx/plain_gtmp_probe.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# [DONOTMERGE] Validate Darwin non-VMA gtmp/listgen against the MoltenVK hang.
+#
+# Baseline (stock VMA for gtmp+listgen): bare qd.init(vulkan)/qd.reset() aborts ~2900 cycles
+# with kIOGPUCommandBufferCallbackErrorHang / VK_ERROR_DEVICE_LOST.
+# Expectation with bypass_pooled_allocator on those two buffers: LEAK_DONE at 5000, rc=0.
+
+set -x
+OUT="${RUNNER_TEMP}/plain_gtmp_out"; mkdir -p "$OUT"
+export QD_LIB_DIR="$(python -c 'import quadrants as qd; print(qd.__path__[0])' | tail -n 1)/_lib/runtime"
+export MVK_CONFIG_LOG_LEVEL=1
+echo "python=$(python -V 2>&1) quadrants=$(python -c 'import quadrants as qd; print(getattr(qd,"__version__","?"))' 2>&1)"
+
+run_to() {
+  local secs="$1"; shift
+  "$@" &
+  local cmd_pid=$!
+  ( sleep "$secs"; kill -TERM "$cmd_pid" 2>/dev/null && { sleep 8; kill -KILL "$cmd_pid" 2>/dev/null; } ) &
+  local wd_pid=$!
+  local rc=0
+  wait "$cmd_pid" 2>/dev/null || rc=$?
+  kill "$wd_pid" 2>/dev/null; pkill -P "$wd_pid" 2>/dev/null; wait "$wd_pid" 2>/dev/null || true
+  return "$rc"
+}
+
+PROBE_PY="${RUNNER_TEMP}/plain_gtmp_probe.py"
+cat > "$PROBE_PY" <<'PY'
+import os, resource
+import quadrants as qd
+
+N = int(os.environ.get("LEAK_CYCLES", "5000"))
+LOG = os.environ.get("LEAK_LOG", "/tmp/leak.txt")
+open(LOG, "w").close()
+
+
+def rss_kb():
+    r = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return r // 1024 if r > 10_000_000 else r
+
+
+print("PLAIN_GTMP bare probe cycles=%d" % N, flush=True)
+i = 0
+try:
+    for i in range(N):
+        qd.init(arch=qd.vulkan)
+        qd.reset()
+        if i % 25 == 0:
+            with open(LOG, "a") as fh:
+                fh.write("cycle=%d max_rss_kb=%d\n" % (i, rss_kb()))
+    print("LEAK_DONE mode=bare ran=%d final_max_rss_kb=%d" % (N, rss_kb()), flush=True)
+except BaseException as e:
+    print("LEAK_THREW mode=bare cycle=%d %s: %s" % (i, type(e).__name__, str(e)[:160]), flush=True)
+    with open(LOG, "a") as fh:
+        fh.write("THREW cycle=%d %s\n" % (i, type(e).__name__))
+    raise
+PY
+
+echo "############### PROBE bare START $(date -u +%H:%M:%SZ) ###############"
+run_to 900 env LEAK_CYCLES=5000 LEAK_LOG="$OUT/bare.txt" python "$PROBE_PY"
+RC=$?
+echo "############### PROBE bare END rc=${RC} $(date -u +%H:%M:%SZ) ###############"
+
+{
+  echo "## Darwin plain gtmp/listgen bare probe"
+  echo ""
+  echo "PASS = \`LEAK_DONE\` at 5000 with rc=0 (past the ~2900 VMA hang). FAIL = abort/device-lost earlier."
+  echo ""
+  echo "### bare rc=${RC}"
+  echo '```'
+  if [ -s "$OUT/bare.txt" ]; then
+    head -1 "$OUT/bare.txt"
+    awk 'NR%20==0' "$OUT/bare.txt" | tail -6
+    echo "-- last line --"; tail -1 "$OUT/bare.txt"
+    awk -F'[= ]' '/^cycle=/{c=$2; r=$4; if(f0==0){c0=c; r0=r; f0=1}} END{if(c>c0) printf "SLOPE bare = %.2f kb/cycle  (%d -> %d kb over %d cycles)\n",(r-r0)/(c-c0),r0,r,c-c0}' "$OUT/bare.txt"
+  else
+    echo "(no data)"
+  fi
+  echo '```'
+} >> "$GITHUB_STEP_SUMMARY"
+
+exit "$RC"

--- a/quadrants/rhi/public_device.h
+++ b/quadrants/rhi/public_device.h
@@ -613,6 +613,10 @@ class RHI_DLL_EXPORT Device {
     bool host_read{false};
     bool export_sharing{false};
     AllocUsage usage{AllocUsage::Storage};
+    // When true, backends that use a pooled allocator (Vulkan/VMA) allocate a dedicated
+    // VkDeviceMemory via vkAllocateMemory instead. Used on Darwin for gtmp/listgen to avoid a
+    // MoltenVK hang triggered by VMA's pooled path for those two sizes (see Mac CI investigation).
+    bool bypass_pooled_allocator{false};
   };
 
   virtual RhiResult allocate_memory(const AllocParams &params, DeviceAllocation *out_devalloc) = 0;

--- a/quadrants/rhi/vulkan/vulkan_api.cpp
+++ b/quadrants/rhi/vulkan/vulkan_api.cpp
@@ -87,6 +87,12 @@ DeviceObjVkPipelineCache::~DeviceObjVkPipelineCache() {
 DeviceObjVkBuffer::~DeviceObjVkBuffer() {
   if (allocation) {
     vmaDestroyBuffer(allocator, buffer, allocation);
+  } else if (device_memory != VK_NULL_HANDLE) {
+    // Unpooled path: we own both the VkBuffer and its dedicated VkDeviceMemory.
+    if (buffer != VK_NULL_HANDLE) {
+      vkDestroyBuffer(device, buffer, nullptr);
+    }
+    vkFreeMemory(device, device_memory, nullptr);
   }
 }
 
@@ -529,6 +535,91 @@ IVkBuffer create_buffer(VkDevice device,
   BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to create buffer");
 
   return buffer;
+}
+
+IVkBuffer create_buffer_unpooled(VkDevice device,
+                                 VkPhysicalDevice physical_device,
+                                 VkBufferCreateInfo *buffer_info,
+                                 VkMemoryPropertyFlags required_flags,
+                                 VkMemoryPropertyFlags preferred_flags,
+                                 VmaAllocationInfo *out_alloc_info) {
+  IVkBuffer obj = std::make_shared<DeviceObjVkBuffer>();
+  obj->device = device;
+  obj->usage = buffer_info->usage;
+
+  VkResult res = vkCreateBuffer(device, buffer_info, nullptr, &obj->buffer);
+  if (res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+    return nullptr;
+  }
+  BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to create unpooled buffer");
+
+  VkMemoryRequirements mr{};
+  vkGetBufferMemoryRequirements(device, obj->buffer, &mr);
+
+  VkPhysicalDeviceMemoryProperties mp{};
+  vkGetPhysicalDeviceMemoryProperties(physical_device, &mp);
+
+  auto pick_type = [&](VkMemoryPropertyFlags want) -> uint32_t {
+    for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+      if ((mr.memoryTypeBits & (1u << i)) == 0) {
+        continue;
+      }
+      if ((mp.memoryTypes[i].propertyFlags & want) == want) {
+        return i;
+      }
+    }
+    return UINT32_MAX;
+  };
+
+  uint32_t type_index = UINT32_MAX;
+  if (preferred_flags != 0) {
+    // Prefer the intersection of required+preferred when possible (e.g. DEVICE_LOCAL and not
+    // merely the first type that matches required alone).
+    type_index = pick_type(required_flags | preferred_flags);
+  }
+  if (type_index == UINT32_MAX) {
+    type_index = pick_type(required_flags);
+  }
+  if (type_index == UINT32_MAX) {
+    vkDestroyBuffer(device, obj->buffer, nullptr);
+    obj->buffer = VK_NULL_HANDLE;
+    return nullptr;
+  }
+
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.allocationSize = mr.size;
+  mai.memoryTypeIndex = type_index;
+
+  // Buffers created with SHADER_DEVICE_ADDRESS need the matching allocate-info flag on drivers
+  // that enforce bufferDeviceAddress capture/replay rules; MoltenVK tolerates either, but keep
+  // the Vulkan-correct path.
+  VkMemoryAllocateFlagsInfo flags_info{};
+  if (buffer_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR) {
+    flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+    flags_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
+    mai.pNext = &flags_info;
+  }
+
+  res = vkAllocateMemory(device, &mai, nullptr, &obj->device_memory);
+  if (res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+    vkDestroyBuffer(device, obj->buffer, nullptr);
+    obj->buffer = VK_NULL_HANDLE;
+    return nullptr;
+  }
+  BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to allocate unpooled device memory");
+
+  res = vkBindBufferMemory(device, obj->buffer, obj->device_memory, 0);
+  BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to bind unpooled buffer memory");
+
+  if (out_alloc_info) {
+    *out_alloc_info = {};
+    out_alloc_info->deviceMemory = obj->device_memory;
+    out_alloc_info->offset = 0;
+    out_alloc_info->size = mr.size;
+  }
+
+  return obj;
 }
 
 IVkBuffer create_buffer(VkDevice device, VkBuffer buffer, VkBufferUsageFlags usage) {

--- a/quadrants/rhi/vulkan/vulkan_api.h
+++ b/quadrants/rhi/vulkan/vulkan_api.h
@@ -230,6 +230,8 @@ struct DeviceObjVkBuffer : public DeviceObj {
   VkBufferUsageFlags usage{0};
   VmaAllocator allocator{nullptr};
   VmaAllocation allocation{nullptr};
+  // Non-VMA ownership (bypass_pooled_allocator). Mutually exclusive with `allocation`.
+  VkDeviceMemory device_memory{VK_NULL_HANDLE};
   ~DeviceObjVkBuffer() override;
 };
 using IVkBuffer = std::shared_ptr<DeviceObjVkBuffer>;
@@ -238,6 +240,13 @@ IVkBuffer create_buffer(VkDevice device,
                         VmaAllocator allocator,
                         VkBufferCreateInfo *buffer_info,
                         VmaAllocationCreateInfo *alloc_info);
+// Allocate buffer with a dedicated vkAllocateMemory (no VMA). Owns buffer + device_memory.
+IVkBuffer create_buffer_unpooled(VkDevice device,
+                                 VkPhysicalDevice physical_device,
+                                 VkBufferCreateInfo *buffer_info,
+                                 VkMemoryPropertyFlags required_flags,
+                                 VkMemoryPropertyFlags preferred_flags,
+                                 VmaAllocationInfo *out_alloc_info);
 // Importing external buffer
 IVkBuffer create_buffer(VkDevice device, VkBuffer buffer, VkBufferUsageFlags usage);
 

--- a/quadrants/rhi/vulkan/vulkan_device.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device.cpp
@@ -1641,13 +1641,24 @@ RhiResult VulkanDevice::allocate_memory(const AllocParams &params, DeviceAllocat
     buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
   }
 
-  alloc.buffer =
-      vkapi::create_buffer(device_, export_sharing ? allocator_export_ : allocator_, &buffer_info, &alloc_info);
-  if (alloc.buffer == nullptr) {
-    return RhiResult::out_of_memory;
-  }
+  if (params.bypass_pooled_allocator) {
+    // Dedicated vkAllocateMemory path (no VMA). Used on Darwin for gtmp/listgen: the standalone
+    // MoltenVK repro hangs when those two DEVICE_LOCAL sizes go through VMA, but not when the same
+    // sizes use plain vkAllocateMemory.
+    alloc.buffer = vkapi::create_buffer_unpooled(device_, physical_device_, &buffer_info, alloc_info.requiredFlags,
+                                                 alloc_info.preferredFlags, &alloc.alloc_info);
+    if (alloc.buffer == nullptr) {
+      return RhiResult::out_of_memory;
+    }
+  } else {
+    alloc.buffer =
+        vkapi::create_buffer(device_, export_sharing ? allocator_export_ : allocator_, &buffer_info, &alloc_info);
+    if (alloc.buffer == nullptr) {
+      return RhiResult::out_of_memory;
+    }
 
-  vmaGetAllocationInfo(alloc.buffer->allocator, alloc.buffer->allocation, &alloc.alloc_info);
+    vmaGetAllocationInfo(alloc.buffer->allocator, alloc.buffer->allocation, &alloc.alloc_info);
+  }
 
   if (get_caps().get(DeviceCapability::spirv_has_physical_storage_buffer) &&
       (buffer_info.usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR)) {

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -1236,17 +1236,27 @@ void GfxRuntime::submit_current_cmdlist_if_timeout() {
 
 void GfxRuntime::init_nonroot_buffers() {
   {
-    auto [buf, res] = device_->allocate_memory_unique({kGtmpBufferSize,
-                                                       /*host_write=*/false, /*host_read=*/false,
-                                                       /*export_sharing=*/false, AllocUsage::Storage});
+    Device::AllocParams params{kGtmpBufferSize,
+                               /*host_write=*/false, /*host_read=*/false,
+                               /*export_sharing=*/false, AllocUsage::Storage};
+#ifdef __APPLE__
+    // MoltenVK hang: VMA-backed 1MB+32MB DEVICE_LOCAL STORAGE+BDA churn under per-cycle device
+    // recreate; plain vkAllocateMemory of the same sizes does not hang (standalone repro).
+    params.bypass_pooled_allocator = true;
+#endif
+    auto [buf, res] = device_->allocate_memory_unique(params);
     QD_ASSERT_INFO(res == RhiResult::success, "gtmp allocation failed");
     global_tmps_buffer_ = std::move(buf);
   }
 
   {
-    auto [buf, res] = device_->allocate_memory_unique({kListGenBufferSize,
-                                                       /*host_write=*/false, /*host_read=*/false,
-                                                       /*export_sharing=*/false, AllocUsage::Storage});
+    Device::AllocParams params{kListGenBufferSize,
+                               /*host_write=*/false, /*host_read=*/false,
+                               /*export_sharing=*/false, AllocUsage::Storage};
+#ifdef __APPLE__
+    params.bypass_pooled_allocator = true;
+#endif
+    auto [buf, res] = device_->allocate_memory_unique(params);
     QD_ASSERT_INFO(res == RhiResult::success, "listgen allocation failed");
     listgen_buffer_ = std::move(buf);
   }


### PR DESCRIPTION
## Summary
- Experiment only: on Apple, allocate gtmp (1MB) + listgen (32MB) via plain `vkAllocateMemory` instead of VMA (`bypass_pooled_allocator`).
- Motivated by standalone repro: VMA 1MB+32MB hangs ~3879 with `kIOGPUCommandBufferCallbackErrorHang`; plain alloc of same sizes does not.
- Mac CI job builds one wheel and runs bare `qd.init(vulkan)`/`qd.reset()` to 5000 cycles (baseline hangs ~2900).

## Test plan
- [ ] `plain_gtmp_probe` job: `LEAK_DONE` at 5000, rc=0
- [ ] If still hangs ~2900: other VMA allocs (or non-alloc path) still trigger; keep worker recycle
- [ ] Do not merge either way without a proper non-DONOTMERGE follow-up


Made with [Cursor](https://cursor.com)