### PR TITLE
[Bug] Bypass VMA for gtmp/listgen buffers on Darwin

### DIFF
--- a/quadrants/rhi/public_device.h
+++ b/quadrants/rhi/public_device.h
@@ -613,6 +613,10 @@ class RHI_DLL_EXPORT Device {
     bool host_read{false};
     bool export_sharing{false};
     AllocUsage usage{AllocUsage::Storage};
+    // When true, backends that use a pooled allocator (Vulkan/VMA) allocate a dedicated
+    // VkDeviceMemory via vkAllocateMemory instead. On Darwin this is set for gtmp/listgen to
+    // avoid a MoltenVK GPU hang from VMA's pooled path for those two DEVICE_LOCAL sizes.
+    bool bypass_pooled_allocator{false};
   };
 
   virtual RhiResult allocate_memory(const AllocParams &params, DeviceAllocation *out_devalloc) = 0;

--- a/quadrants/rhi/public_device.h
+++ b/quadrants/rhi/public_device.h
@@ -613,9 +613,9 @@ class RHI_DLL_EXPORT Device {
     bool host_read{false};
     bool export_sharing{false};
     AllocUsage usage{AllocUsage::Storage};
-    // When true, backends that use a pooled allocator (Vulkan/VMA) allocate a dedicated
-    // VkDeviceMemory via vkAllocateMemory instead. On Darwin this is set for gtmp/listgen to
-    // avoid a MoltenVK GPU hang from VMA's pooled path for those two DEVICE_LOCAL sizes.
+    // When true, backends that use a pooled allocator (Vulkan/VMA) allocate a dedicated VkDeviceMemory via
+    // vkAllocateMemory instead. On Darwin this is set for gtmp/listgen to avoid a MoltenVK GPU hang from VMA's pooled
+    // path for those two DEVICE_LOCAL sizes.
     bool bypass_pooled_allocator{false};
   };
 

--- a/quadrants/rhi/vulkan/vulkan_api.cpp
+++ b/quadrants/rhi/vulkan/vulkan_api.cpp
@@ -573,8 +573,8 @@ IVkBuffer create_buffer_unpooled(VkDevice device,
 
   uint32_t type_index = UINT32_MAX;
   if (preferred_flags != 0) {
-    // Prefer the intersection of required+preferred when possible (e.g. DEVICE_LOCAL and not
-    // merely the first type that matches required alone).
+    // Prefer the intersection of required+preferred when possible (e.g. DEVICE_LOCAL and not merely the first type
+    // that matches required alone).
     type_index = pick_type(required_flags | preferred_flags);
   }
   if (type_index == UINT32_MAX) {
@@ -591,9 +591,8 @@ IVkBuffer create_buffer_unpooled(VkDevice device,
   mai.allocationSize = mr.size;
   mai.memoryTypeIndex = type_index;
 
-  // Buffers created with SHADER_DEVICE_ADDRESS need the matching allocate-info flag on drivers
-  // that enforce bufferDeviceAddress capture/replay rules; MoltenVK tolerates either, but keep
-  // the Vulkan-correct path.
+  // Buffers created with SHADER_DEVICE_ADDRESS need the matching allocate-info flag on drivers that enforce
+  // bufferDeviceAddress capture/replay rules; MoltenVK tolerates either, but keep the Vulkan-correct path.
   VkMemoryAllocateFlagsInfo flags_info{};
   if (buffer_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR) {
     flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;

--- a/quadrants/rhi/vulkan/vulkan_api.cpp
+++ b/quadrants/rhi/vulkan/vulkan_api.cpp
@@ -87,6 +87,12 @@ DeviceObjVkPipelineCache::~DeviceObjVkPipelineCache() {
 DeviceObjVkBuffer::~DeviceObjVkBuffer() {
   if (allocation) {
     vmaDestroyBuffer(allocator, buffer, allocation);
+  } else if (device_memory != VK_NULL_HANDLE) {
+    // Unpooled path: we own both the VkBuffer and its dedicated VkDeviceMemory.
+    if (buffer != VK_NULL_HANDLE) {
+      vkDestroyBuffer(device, buffer, nullptr);
+    }
+    vkFreeMemory(device, device_memory, nullptr);
   }
 }
 
@@ -529,6 +535,91 @@ IVkBuffer create_buffer(VkDevice device,
   BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to create buffer");
 
   return buffer;
+}
+
+IVkBuffer create_buffer_unpooled(VkDevice device,
+                                 VkPhysicalDevice physical_device,
+                                 VkBufferCreateInfo *buffer_info,
+                                 VkMemoryPropertyFlags required_flags,
+                                 VkMemoryPropertyFlags preferred_flags,
+                                 VmaAllocationInfo *out_alloc_info) {
+  IVkBuffer obj = std::make_shared<DeviceObjVkBuffer>();
+  obj->device = device;
+  obj->usage = buffer_info->usage;
+
+  VkResult res = vkCreateBuffer(device, buffer_info, nullptr, &obj->buffer);
+  if (res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+    return nullptr;
+  }
+  BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to create unpooled buffer");
+
+  VkMemoryRequirements mr{};
+  vkGetBufferMemoryRequirements(device, obj->buffer, &mr);
+
+  VkPhysicalDeviceMemoryProperties mp{};
+  vkGetPhysicalDeviceMemoryProperties(physical_device, &mp);
+
+  auto pick_type = [&](VkMemoryPropertyFlags want) -> uint32_t {
+    for (uint32_t i = 0; i < mp.memoryTypeCount; ++i) {
+      if ((mr.memoryTypeBits & (1u << i)) == 0) {
+        continue;
+      }
+      if ((mp.memoryTypes[i].propertyFlags & want) == want) {
+        return i;
+      }
+    }
+    return UINT32_MAX;
+  };
+
+  uint32_t type_index = UINT32_MAX;
+  if (preferred_flags != 0) {
+    // Prefer the intersection of required+preferred when possible (e.g. DEVICE_LOCAL and not
+    // merely the first type that matches required alone).
+    type_index = pick_type(required_flags | preferred_flags);
+  }
+  if (type_index == UINT32_MAX) {
+    type_index = pick_type(required_flags);
+  }
+  if (type_index == UINT32_MAX) {
+    vkDestroyBuffer(device, obj->buffer, nullptr);
+    obj->buffer = VK_NULL_HANDLE;
+    return nullptr;
+  }
+
+  VkMemoryAllocateInfo mai{};
+  mai.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO;
+  mai.allocationSize = mr.size;
+  mai.memoryTypeIndex = type_index;
+
+  // Buffers created with SHADER_DEVICE_ADDRESS need the matching allocate-info flag on drivers
+  // that enforce bufferDeviceAddress capture/replay rules; MoltenVK tolerates either, but keep
+  // the Vulkan-correct path.
+  VkMemoryAllocateFlagsInfo flags_info{};
+  if (buffer_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR) {
+    flags_info.sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO;
+    flags_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
+    mai.pNext = &flags_info;
+  }
+
+  res = vkAllocateMemory(device, &mai, nullptr, &obj->device_memory);
+  if (res == VK_ERROR_OUT_OF_DEVICE_MEMORY || res == VK_ERROR_OUT_OF_HOST_MEMORY) {
+    vkDestroyBuffer(device, obj->buffer, nullptr);
+    obj->buffer = VK_NULL_HANDLE;
+    return nullptr;
+  }
+  BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to allocate unpooled device memory");
+
+  res = vkBindBufferMemory(device, obj->buffer, obj->device_memory, 0);
+  BAIL_ON_VK_BAD_RESULT_NO_RETURN(res, "failed to bind unpooled buffer memory");
+
+  if (out_alloc_info) {
+    *out_alloc_info = {};
+    out_alloc_info->deviceMemory = obj->device_memory;
+    out_alloc_info->offset = 0;
+    out_alloc_info->size = mr.size;
+  }
+
+  return obj;
 }
 
 IVkBuffer create_buffer(VkDevice device, VkBuffer buffer, VkBufferUsageFlags usage) {

--- a/quadrants/rhi/vulkan/vulkan_api.h
+++ b/quadrants/rhi/vulkan/vulkan_api.h
@@ -230,6 +230,8 @@ struct DeviceObjVkBuffer : public DeviceObj {
   VkBufferUsageFlags usage{0};
   VmaAllocator allocator{nullptr};
   VmaAllocation allocation{nullptr};
+  // Non-VMA ownership (bypass_pooled_allocator). Mutually exclusive with `allocation`.
+  VkDeviceMemory device_memory{VK_NULL_HANDLE};
   ~DeviceObjVkBuffer() override;
 };
 using IVkBuffer = std::shared_ptr<DeviceObjVkBuffer>;
@@ -238,6 +240,13 @@ IVkBuffer create_buffer(VkDevice device,
                         VmaAllocator allocator,
                         VkBufferCreateInfo *buffer_info,
                         VmaAllocationCreateInfo *alloc_info);
+// Allocate buffer with a dedicated vkAllocateMemory (no VMA). Owns buffer + device_memory.
+IVkBuffer create_buffer_unpooled(VkDevice device,
+                                 VkPhysicalDevice physical_device,
+                                 VkBufferCreateInfo *buffer_info,
+                                 VkMemoryPropertyFlags required_flags,
+                                 VkMemoryPropertyFlags preferred_flags,
+                                 VmaAllocationInfo *out_alloc_info);
 // Importing external buffer
 IVkBuffer create_buffer(VkDevice device, VkBuffer buffer, VkBufferUsageFlags usage);
 

--- a/quadrants/rhi/vulkan/vulkan_device.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device.cpp
@@ -1642,9 +1642,8 @@ RhiResult VulkanDevice::allocate_memory(const AllocParams &params, DeviceAllocat
   }
 
   if (params.bypass_pooled_allocator) {
-    // Dedicated vkAllocateMemory path (no VMA). Used on Darwin for gtmp/listgen: the standalone
-    // MoltenVK repro hangs when those two DEVICE_LOCAL sizes go through VMA, but not when the same
-    // sizes use plain vkAllocateMemory.
+    // Dedicated vkAllocateMemory path (no VMA). Used on Darwin for gtmp/listgen: the standalone MoltenVK repro hangs
+    // when those two DEVICE_LOCAL sizes go through VMA, but not when the same sizes use plain vkAllocateMemory.
     alloc.buffer = vkapi::create_buffer_unpooled(device_, physical_device_, &buffer_info, alloc_info.requiredFlags,
                                                  alloc_info.preferredFlags, &alloc.alloc_info);
     if (alloc.buffer == nullptr) {

--- a/quadrants/rhi/vulkan/vulkan_device.cpp
+++ b/quadrants/rhi/vulkan/vulkan_device.cpp
@@ -1641,13 +1641,24 @@ RhiResult VulkanDevice::allocate_memory(const AllocParams &params, DeviceAllocat
     buffer_info.usage |= VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR;
   }
 
-  alloc.buffer =
-      vkapi::create_buffer(device_, export_sharing ? allocator_export_ : allocator_, &buffer_info, &alloc_info);
-  if (alloc.buffer == nullptr) {
-    return RhiResult::out_of_memory;
-  }
+  if (params.bypass_pooled_allocator) {
+    // Dedicated vkAllocateMemory path (no VMA). Used on Darwin for gtmp/listgen: the standalone
+    // MoltenVK repro hangs when those two DEVICE_LOCAL sizes go through VMA, but not when the same
+    // sizes use plain vkAllocateMemory.
+    alloc.buffer = vkapi::create_buffer_unpooled(device_, physical_device_, &buffer_info, alloc_info.requiredFlags,
+                                                 alloc_info.preferredFlags, &alloc.alloc_info);
+    if (alloc.buffer == nullptr) {
+      return RhiResult::out_of_memory;
+    }
+  } else {
+    alloc.buffer =
+        vkapi::create_buffer(device_, export_sharing ? allocator_export_ : allocator_, &buffer_info, &alloc_info);
+    if (alloc.buffer == nullptr) {
+      return RhiResult::out_of_memory;
+    }
 
-  vmaGetAllocationInfo(alloc.buffer->allocator, alloc.buffer->allocation, &alloc.alloc_info);
+    vmaGetAllocationInfo(alloc.buffer->allocator, alloc.buffer->allocation, &alloc.alloc_info);
+  }
 
   if (get_caps().get(DeviceCapability::spirv_has_physical_storage_buffer) &&
       (buffer_info.usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR)) {

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -1240,8 +1240,8 @@ void GfxRuntime::init_nonroot_buffers() {
                                /*host_write=*/false, /*host_read=*/false,
                                /*export_sharing=*/false, AllocUsage::Storage};
 #ifdef __APPLE__
-    // MoltenVK hang: VMA-backed 1MB+32MB DEVICE_LOCAL STORAGE+BDA churn under per-cycle device
-    // recreate; plain vkAllocateMemory of the same sizes does not hang (standalone repro).
+    // MoltenVK hang: VMA-backed 1MB+32MB DEVICE_LOCAL STORAGE+BDA churn under per-cycle device recreate; plain
+    // vkAllocateMemory of the same sizes does not hang (standalone repro).
     params.bypass_pooled_allocator = true;
 #endif
     auto [buf, res] = device_->allocate_memory_unique(params);

--- a/quadrants/runtime/gfx/runtime.cpp
+++ b/quadrants/runtime/gfx/runtime.cpp
@@ -1236,17 +1236,27 @@ void GfxRuntime::submit_current_cmdlist_if_timeout() {
 
 void GfxRuntime::init_nonroot_buffers() {
   {
-    auto [buf, res] = device_->allocate_memory_unique({kGtmpBufferSize,
-                                                       /*host_write=*/false, /*host_read=*/false,
-                                                       /*export_sharing=*/false, AllocUsage::Storage});
+    Device::AllocParams params{kGtmpBufferSize,
+                               /*host_write=*/false, /*host_read=*/false,
+                               /*export_sharing=*/false, AllocUsage::Storage};
+#ifdef __APPLE__
+    // MoltenVK hang: VMA-backed 1MB+32MB DEVICE_LOCAL STORAGE+BDA churn under per-cycle device
+    // recreate; plain vkAllocateMemory of the same sizes does not hang (standalone repro).
+    params.bypass_pooled_allocator = true;
+#endif
+    auto [buf, res] = device_->allocate_memory_unique(params);
     QD_ASSERT_INFO(res == RhiResult::success, "gtmp allocation failed");
     global_tmps_buffer_ = std::move(buf);
   }
 
   {
-    auto [buf, res] = device_->allocate_memory_unique({kListGenBufferSize,
-                                                       /*host_write=*/false, /*host_read=*/false,
-                                                       /*export_sharing=*/false, AllocUsage::Storage});
+    Device::AllocParams params{kListGenBufferSize,
+                               /*host_write=*/false, /*host_read=*/false,
+                               /*export_sharing=*/false, AllocUsage::Storage};
+#ifdef __APPLE__
+    params.bypass_pooled_allocator = true;
+#endif
+    auto [buf, res] = device_->allocate_memory_unique(params);
     QD_ASSERT_INFO(res == RhiResult::success, "listgen allocation failed");
     listgen_buffer_ = std::move(buf);
   }


### PR DESCRIPTION
## Summary
- On Apple/MoltenVK, allocate the fixed gtmp (1MB) and listgen (32MB) runtime buffers with plain `vkAllocateMemory` instead of VMA (`AllocParams::bypass_pooled_allocator`).
- Motivated by a standalone no-Quadrants repro: VMA allocation of both sizes under per-cycle `VkDevice` churn hangs with `kIOGPUCommandBufferCallbackErrorHang` / `VK_ERROR_DEVICE_LOST`; the same sizes via `vkAllocateMemory` do not.
- Validated on macos-26: bare `qd.init(vulkan)` / `qd.reset()` reaches 5000 cycles (`LEAK_DONE`, rc=0) with this change; baseline aborted around ~2900. Other VMA allocations remain and were not sufficient alone to trigger the hang on that path.
- Linux/Windows and non-gtmp/listgen Vulkan allocations are unchanged.

## Test plan
- [x] Mac bare init/reset probe to 5000 cycles on the experiment branch (#833 / run 30708349366)
- [ ] Mac CI vulkan legs green on this PR
- [ ] Spot-check metal/cpu legs unaffected
- [ ] Optional follow-up: keep worker recycle (#832) as defense-in-depth for full-suite residual risk


Made with [Cursor](https://cursor.com)