### PR TITLE
[Docs] Document that Tile.cholesky_ eps may be per-lane

### DIFF
--- a/docs/source/user_guide/tile.md
+++ b/docs/source/user_guide/tile.md
@@ -104,7 +104,7 @@ t.cholesky_(eps)
 
 Factorizes the tile in-place: replaces the lower triangle with `L` such that `L @ L^T ≈ A`. The `eps` parameter clamps the diagonal to avoid numerical issues with near-singular matrices. After this call, the lower triangle of `t` contains `L`.
 
-`eps` may be a single uniform value (the common case) or a per-lane value: it is read only on the lane that owns each pivot, so lane `k` supplies the floor for pivot `k`. Use a per-lane `eps` when you want the floor to be *relative* to each row rather than one absolute value for the whole tile: pass `eps_rel * A_orig[k]`, where `A_orig[k]` is row `k`'s original diagonal, for a scale-invariant floor. Note that in a blocked factorization the tile handed to `cholesky_` is the Schur complement of the diagonal block, so its in-register diagonal is *not* the original `A[k][k]`; a relative floor must therefore use the original diagonal you supply, not the tile's current contents.
+`eps` may be a single uniform value (the common case) or a per-lane value: it is read only on the lane that owns each pivot, so lane `k` supplies the floor for pivot `k`.
 
 ```python
 # Per-lane (relative) floor: lane k floors pivot k using its own row's original diagonal.

--- a/docs/source/user_guide/tile.md
+++ b/docs/source/user_guide/tile.md
@@ -104,7 +104,7 @@ t.cholesky_(eps)
 
 Factorizes the tile in-place: replaces the lower triangle with `L` such that `L @ L^T ≈ A`. The `eps` parameter clamps the diagonal to avoid numerical issues with near-singular matrices. After this call, the lower triangle of `t` contains `L`.
 
-`eps` may be a single uniform value (the common case) or a per-lane value: it is read only on the lane that owns each pivot, so lane `k` supplies the floor for pivot `k`.
+`eps` may be a single uniform value or a per-lane value: it is read only on the lane that owns each pivot, so lane `k` supplies the floor for pivot `k`.
 
 ```python
 # Per-lane (relative) floor: lane k floors pivot k using its own row's original diagonal.

--- a/docs/source/user_guide/tile.md
+++ b/docs/source/user_guide/tile.md
@@ -104,6 +104,14 @@ t.cholesky_(eps)
 
 Factorizes the tile in-place: replaces the lower triangle with `L` such that `L @ L^T ≈ A`. The `eps` parameter clamps the diagonal to avoid numerical issues with near-singular matrices. After this call, the lower triangle of `t` contains `L`.
 
+`eps` may be a single uniform value (the common case) or a per-lane value: it is read only on the lane that owns each pivot, so lane `k` supplies the floor for pivot `k`. Use a per-lane `eps` when you want the floor to be *relative* to each row rather than one absolute value for the whole tile: pass `eps_rel * A_orig[k]`, where `A_orig[k]` is row `k`'s original diagonal, for a scale-invariant floor. Note that in a blocked factorization the tile handed to `cholesky_` is the Schur complement of the diagonal block, so its in-register diagonal is *not* the original `A[k][k]`; a relative floor must therefore use the original diagonal you supply, not the tile's current contents.
+
+```python
+# Per-lane (relative) floor: lane k floors pivot k using its own row's original diagonal.
+tid = qd.simt.subgroup.invocation_id()
+t.cholesky_(eps_rel * a_orig_diag[tid])
+```
+
 ## Triangular solve
 
 ```python

--- a/python/quadrants/lang/simt/_tile.py
+++ b/python/quadrants/lang/simt/_tile.py
@@ -307,8 +307,16 @@ def _make_tile_class(N: int, dtype):
         def cholesky_(self, eps):
             """In-place NxN Cholesky factorization via subgroup shuffles.
 
-            On return, the lower triangle holds L such that A = L @ L^T.  Diagonal clamped to sqrt(max(value, eps)) for
-            numerical stability.
+            On return, the lower triangle holds L such that A = L @ L^T.  Each pivot is floored as
+            sqrt(max(value, eps)) for numerical stability.
+
+            ``eps`` may be uniform or per-lane.  It is read only on the single lane that owns pivot ``k`` (the
+            ``tid == k`` branch below), so passing a thread-varying value floors pivot ``k`` with lane ``k``'s own
+            ``eps`` at no extra cost (no shuffle, no broadcast).  A caller that wants the floor relative to each row's
+            original diagonal should pass ``eps_rel * A_orig[k]`` per lane, where ``A_orig[k]`` is the ORIGINAL
+            diagonal it supplies: in a blocked factorization ``self.r[k]`` here is the Schur complement of the diagonal
+            block, not the original A[k][k], so flooring against it would instead give a floor relative to the Schur
+            complement.
             """
             # ``k`` and ``j`` are wrapped in qd.static so the ``if k > j`` predicate folds at compile time and the
             # ``self.r[k]`` / ``self.r[j]`` accesses resolve to a single unpacked-register slot per use (no runtime


### PR DESCRIPTION
## Summary

Documents that the `eps` argument of `TileNxN.cholesky_` may be supplied per-lane (thread-varying), not just as a uniform scalar. This is a docstring-only change; the factorization is unchanged.

`eps` is consumed only on the single lane that owns each pivot (the `tid == k` branch), so passing a thread-varying value floors pivot `k` with lane `k`'s own `eps` at no extra cost - no shuffle, no broadcast, no dynamic register index. This lets a caller express a floor **relative to each row's original diagonal** (`eps_rel * A_orig[k]`) instead of a single absolute floor for the whole tile.

The docstring also warns that `A_orig[k]` must be the caller's original diagonal: in a blocked factorization `self.r[k]` at the floor point is the Schur complement of the diagonal block, not the original `A[k][k]`, so flooring against the in-register value would give a floor relative to the Schur complement instead.

Motivated by [#836](https://github.com/Genesis-Embodied-AI/quadrants/issues/836) (absolute pivot floor is not scale-invariant). The per-lane capability already exists; this just makes the contract explicit so callers can rely on it.

## Test plan

- [ ] No functional change - docstring only; existing `test_potrf` / `test_potrf_then_trsm` coverage is unaffected.
- [ ] Verified locally that a thread-varying `eps` compiles and runs and floors each pivot per-row (matches an unblocked per-row-floored reference to f32 precision) on an RTX PRO 6000; a regression test can be added in a follow-up.

Made with [Cursor](https://cursor.com)