### PR TITLE
[perf_dispatch] Default repeat_after_count/seconds to None

### DIFF
--- a/docs/source/user_guide/perf_dispatch.md
+++ b/docs/source/user_guide/perf_dispatch.md
@@ -123,10 +123,10 @@ Guidelines for `get_geometry_hash`:
 |---|---|---|
 | `warmup` | 3 | Number of untimed warmup calls per implementation before measuring. |
 | `active` | 1 | Number of timed calls per implementation. |
-| `repeat_after_count` | `None` | Re-run benchmarking after this many additional calls. `0` (or less) disables; `None` means unset. |
-| `repeat_after_seconds` | `None` | Re-run benchmarking after this many seconds have elapsed. `0` (or less) disables; `None` means unset. |
+| `repeat_after_count` | `None` | Re-run benchmarking after this many additional calls. `0` (or less) disables; `None` lets `perf_dispatch` choose. |
+| `repeat_after_seconds` | `None` | Re-run benchmarking after this many seconds have elapsed. `0` (or less) disables; `None` lets `perf_dispatch` choose. |
 
-`repeat_after_count` and `repeat_after_seconds` are OR'd — whichever fires first restarts benchmarking. When **both** are left unset (`None`), `perf_dispatch` picks an internal default of `repeat_after_count=300` with no time-based trigger. Passing only one of them leaves the other unset, so exactly the requested trigger is used (e.g. `repeat_after_count=300` re-benchmarks purely by call count, with no hidden per-second re-evaluation).
+`repeat_after_count` and `repeat_after_seconds` are OR'd — whichever fires first restarts benchmarking. A `None` trigger means "choose a suitable value for me": if you give the other trigger an explicit value, the `None` one is left off; if you leave **both** as `None`, `perf_dispatch` re-benchmarks every 300 calls with no time-based trigger (so, e.g., `repeat_after_count=300` re-benchmarks purely by call count, with no hidden per-second re-evaluation).
 
 Example with custom tuning:
 

--- a/docs/source/user_guide/perf_dispatch.md
+++ b/docs/source/user_guide/perf_dispatch.md
@@ -123,8 +123,10 @@ Guidelines for `get_geometry_hash`:
 |---|---|---|
 | `warmup` | 3 | Number of untimed warmup calls per implementation before measuring. |
 | `active` | 1 | Number of timed calls per implementation. |
-| `repeat_after_count` | 0 | Re-run benchmarking after this many additional calls. 0 disables. |
-| `repeat_after_seconds` | 1.0 | Re-run benchmarking after this many seconds have elapsed. 0 disables. |
+| `repeat_after_count` | `None` | Re-run benchmarking after this many additional calls. `0` (or less) disables; `None` means unset. |
+| `repeat_after_seconds` | `None` | Re-run benchmarking after this many seconds have elapsed. `0` (or less) disables; `None` means unset. |
+
+`repeat_after_count` and `repeat_after_seconds` are OR'd — whichever fires first restarts benchmarking. When **both** are left unset (`None`), `perf_dispatch` picks an internal default of `repeat_after_count=300` with no time-based trigger. Passing only one of them leaves the other unset, so exactly the requested trigger is used (e.g. `repeat_after_count=300` re-benchmarks purely by call count, with no hidden per-second re-evaluation).
 
 Example with custom tuning:
 
@@ -144,7 +146,7 @@ def my_op(a: qd.types.NDArray[qd.f32, 1], b: qd.types.NDArray[qd.f32, 1]): ...
 2. **Active phase**: Each compatible implementation is called `active` times in round-robin order. The GPU is synchronized before and after each call to get accurate wall-clock measurements.
 3. **Selection**: The implementation with the lowest active-phase time is cached as the winner for that geometry hash.
 4. **Steady state**: Subsequent calls with the same geometry go directly to the cached winner with no overhead.
-5. **Re-evaluation** (optional): After `repeat_after_count` calls or `repeat_after_seconds` seconds, the entire warmup + active cycle restarts from scratch, allowing the dispatcher to adapt if conditions change.
+5. **Re-evaluation**: After `repeat_after_count` calls or `repeat_after_seconds` seconds (by default, every 300 calls), the entire warmup + active cycle restarts from scratch, allowing the dispatcher to adapt if conditions change.
 
 ## Forcing a specific implementation
 

--- a/docs/source/user_guide/perf_dispatch.md
+++ b/docs/source/user_guide/perf_dispatch.md
@@ -126,7 +126,7 @@ Guidelines for `get_geometry_hash`:
 | `repeat_after_count` | `None` | Re-run benchmarking after this many additional calls. `0` (or less) disables; `None` lets `perf_dispatch` choose. |
 | `repeat_after_seconds` | `None` | Re-run benchmarking after this many seconds have elapsed. `0` (or less) disables; `None` lets `perf_dispatch` choose. |
 
-`repeat_after_count` and `repeat_after_seconds` are OR'd — whichever fires first restarts benchmarking. A `None` trigger means "choose a suitable value for me": if you give the other trigger an explicit value, the `None` one is left off; if you leave **both** as `None`, `perf_dispatch` re-benchmarks every 300 calls with no time-based trigger (so, e.g., `repeat_after_count=300` re-benchmarks purely by call count, with no hidden per-second re-evaluation).
+`repeat_after_count` and `repeat_after_seconds` are OR'd - whichever fires first restarts benchmarking. A `None` trigger means "choose a suitable value for me": if you give the other trigger an explicit value, the `None` one is left off; if you leave **both** as `None`, `perf_dispatch` re-benchmarks every 300 calls with no time-based trigger (so, e.g., `repeat_after_count=300` re-benchmarks purely by call count, with no hidden per-second re-evaluation).
 
 Example with custom tuning:
 

--- a/python/quadrants/lang/_perf_dispatch.py
+++ b/python/quadrants/lang/_perf_dispatch.py
@@ -13,8 +13,8 @@ from .exception import QuadrantsRuntimeError, QuadrantsSyntaxError
 NUM_FIRST_WARMUP: int = 1
 NUM_WARMUP: int = 0
 NUM_ACTIVE: int = 1
-REPEAT_AFTER_COUNT: int = 0
-REPEAT_AFTER_SECONDS: float = 1.0
+# Internal fallback used when the caller specifies neither repeat_after_count nor repeat_after_seconds.
+DEFAULT_REPEAT_AFTER_COUNT: int = 300
 
 QD_PERFDISPATCH_PRINT_DEBUG = os.environ.get("QD_PERFDISPATCH_PRINT_DEBUG", "0") == "1"
 
@@ -82,8 +82,13 @@ class PerformanceDispatcher(Generic[P, R]):
         self.num_first_warmup = num_first_warmup if num_first_warmup is not None else NUM_FIRST_WARMUP
         self.num_warmup = num_warmup if num_warmup is not None else NUM_WARMUP
         self.num_active = num_active if num_active is not None else NUM_ACTIVE
-        self.repeat_after_count = repeat_after_count if repeat_after_count is not None else REPEAT_AFTER_COUNT
-        self.repeat_after_seconds = repeat_after_seconds if repeat_after_seconds is not None else REPEAT_AFTER_SECONDS
+        # repeat_after_count and repeat_after_seconds are OR'd re-benchmarking triggers, where None means "unset"
+        # and a value <= 0 means "explicitly disabled". When BOTH are left unset we fall back to a count-based
+        # default, so the two triggers never silently combine.
+        if repeat_after_count is None and repeat_after_seconds is None:
+            repeat_after_count = DEFAULT_REPEAT_AFTER_COUNT
+        self.repeat_after_count: int | None = repeat_after_count
+        self.repeat_after_seconds: float | None = repeat_after_seconds
         sig = get_func_signature(fn)
         self._param_types: dict[str, Any] = {}
         for param_name, param in sig.parameters.items():
@@ -279,12 +284,12 @@ class PerformanceDispatcher(Generic[P, R]):
         fastest = self._fastest_dispatch_impl_by_geometry_hash.get(geometry_hash)
         if fastest:
             restart_measurements = False
-            if self.repeat_after_count > 0:
+            if self.repeat_after_count is not None and self.repeat_after_count > 0:
                 self._calls_since_last_update_by_geometry_hash[geometry_hash] += 1
                 calls = self._calls_since_last_update_by_geometry_hash[geometry_hash]
                 if calls >= self.repeat_after_count:
                     restart_measurements = True
-            if self.repeat_after_seconds > 0:
+            if self.repeat_after_seconds is not None and self.repeat_after_seconds > 0:
                 elapsed = time.time() - self._last_check_time_by_geometry_hash[geometry_hash]
                 if elapsed >= self.repeat_after_seconds:
                     restart_measurements = True
@@ -346,8 +351,8 @@ def perf_dispatch(
     first_warmup: int = NUM_FIRST_WARMUP,
     warmup: int = NUM_WARMUP,
     active: int = NUM_ACTIVE,
-    repeat_after_count: int = REPEAT_AFTER_COUNT,
-    repeat_after_seconds: float = REPEAT_AFTER_SECONDS,
+    repeat_after_count: int | None = None,
+    repeat_after_seconds: float | None = None,
 ):
     """
     This annotation designates a meta-function that can have one or more functions registered with it.
@@ -364,10 +369,17 @@ def perf_dispatch(
         warmup: Number of warmup iterations for subsequent re-evaluation cycles (default: 0).
             After the first evaluation, kernels are already compiled, so less warmup is needed.
         active: Number of active (timed) iterations to run for each implementation. Default 1.
-        repeat_after_count: repeats the cycle of warmup and active from scratch after repeat_after_count
-        additional calls.
-        repeat_after_seconds: repeats the cycle of warmup and active from scratch after repeat_after_seconds
-        seconds elapsed.
+        repeat_after_count: Re-run the warmup + active benchmarking cycle from scratch after this many
+            additional calls (counted per geometry hash). A value <= 0 disables count-based re-evaluation;
+            None means "unset".
+        repeat_after_seconds: Re-run the warmup + active benchmarking cycle from scratch after this many
+            seconds have elapsed (per geometry hash). A value <= 0 disables time-based re-evaluation;
+            None means "unset".
+
+        repeat_after_count and repeat_after_seconds are OR'd: whichever fires first restarts benchmarking.
+        When BOTH are left as None (the default), perf_dispatch picks an internal default of
+        repeat_after_count=300 with no time-based trigger. Passing only one of them leaves the other unset,
+        so exactly the requested trigger is used.
 
     Example usage:
 

--- a/python/quadrants/lang/_perf_dispatch.py
+++ b/python/quadrants/lang/_perf_dispatch.py
@@ -82,9 +82,9 @@ class PerformanceDispatcher(Generic[P, R]):
         self.num_first_warmup = num_first_warmup if num_first_warmup is not None else NUM_FIRST_WARMUP
         self.num_warmup = num_warmup if num_warmup is not None else NUM_WARMUP
         self.num_active = num_active if num_active is not None else NUM_ACTIVE
-        # repeat_after_count and repeat_after_seconds are OR'd re-benchmarking triggers, where None means "unset"
-        # and a value <= 0 means "explicitly disabled". When BOTH are left unset we fall back to a count-based
-        # default, so the two triggers never silently combine.
+        # repeat_after_count and repeat_after_seconds are OR'd re-benchmarking triggers. None means "choose a
+        # suitable value for me" and a value <= 0 means "explicitly disabled". When BOTH are left as None we
+        # pick a count-based default, so the two triggers never silently combine.
         if repeat_after_count is None and repeat_after_seconds is None:
             repeat_after_count = DEFAULT_REPEAT_AFTER_COUNT
         self.repeat_after_count: int | None = repeat_after_count
@@ -371,15 +371,15 @@ def perf_dispatch(
         active: Number of active (timed) iterations to run for each implementation. Default 1.
         repeat_after_count: Re-run the warmup + active benchmarking cycle from scratch after this many
             additional calls (counted per geometry hash). A value <= 0 disables count-based re-evaluation;
-            None means "unset".
+            None lets perf_dispatch choose a suitable value (see note below).
         repeat_after_seconds: Re-run the warmup + active benchmarking cycle from scratch after this many
             seconds have elapsed (per geometry hash). A value <= 0 disables time-based re-evaluation;
-            None means "unset".
+            None lets perf_dispatch choose a suitable value (see note below).
 
         repeat_after_count and repeat_after_seconds are OR'd: whichever fires first restarts benchmarking.
-        When BOTH are left as None (the default), perf_dispatch picks an internal default of
-        repeat_after_count=300 with no time-based trigger. Passing only one of them leaves the other unset,
-        so exactly the requested trigger is used.
+        A None trigger means "choose a suitable value for me": if the other trigger is given an explicit
+        value, the None one is left off; if both are None, perf_dispatch re-benchmarks every 300 calls
+        with no time-based trigger.
 
     Example usage:
 

--- a/tests/python/test_perf_dispatch.py
+++ b/tests/python/test_perf_dispatch.py
@@ -6,6 +6,7 @@ import pytest
 import quadrants as qd
 from quadrants.lang import _perf_dispatch
 from quadrants.lang._perf_dispatch import (
+    DEFAULT_REPEAT_AFTER_COUNT,
     NUM_FIRST_WARMUP,
     PerformanceDispatcher,
     _parse_force_map,
@@ -444,6 +445,51 @@ def test_perf_dispatch_default_warmup_values() -> None:
         my_func(a)
     assert len(called) == 2
     assert set(called) == {"a", "b"}
+
+
+@test_utils.test()
+def test_perf_dispatch_default_repeat_triggers() -> None:
+    """When neither repeat_after_* is passed, perf_dispatch defaults to count-based re-eval with no time trigger."""
+
+    @qd.perf_dispatch(get_geometry_hash=lambda a: hash(a.shape))
+    def my_func(a: qd.types.NDArray[qd.i32, 1]): ...
+
+    @my_func.register
+    def impl_a(a: qd.types.NDArray[qd.i32, 1]) -> None: ...
+
+    speed_checker = cast(PerformanceDispatcher, my_func)
+    assert speed_checker.repeat_after_count == DEFAULT_REPEAT_AFTER_COUNT
+    assert speed_checker.repeat_after_seconds is None
+
+
+@test_utils.test()
+def test_perf_dispatch_repeat_count_only_leaves_seconds_unset() -> None:
+    """Passing only repeat_after_count leaves the time-based trigger unset (no hidden per-second re-eval)."""
+
+    @qd.perf_dispatch(get_geometry_hash=lambda a: hash(a.shape), repeat_after_count=50)
+    def my_func(a: qd.types.NDArray[qd.i32, 1]): ...
+
+    @my_func.register
+    def impl_a(a: qd.types.NDArray[qd.i32, 1]) -> None: ...
+
+    speed_checker = cast(PerformanceDispatcher, my_func)
+    assert speed_checker.repeat_after_count == 50
+    assert speed_checker.repeat_after_seconds is None
+
+
+@test_utils.test()
+def test_perf_dispatch_repeat_seconds_only_leaves_count_unset() -> None:
+    """Passing only repeat_after_seconds leaves the count-based trigger unset (default 300 is not injected)."""
+
+    @qd.perf_dispatch(get_geometry_hash=lambda a: hash(a.shape), repeat_after_seconds=30.0)
+    def my_func(a: qd.types.NDArray[qd.i32, 1]): ...
+
+    @my_func.register
+    def impl_a(a: qd.types.NDArray[qd.i32, 1]) -> None: ...
+
+    speed_checker = cast(PerformanceDispatcher, my_func)
+    assert speed_checker.repeat_after_seconds == 30.0
+    assert speed_checker.repeat_after_count is None
 
 
 @test_utils.test()


### PR DESCRIPTION
Previously repeat_after_seconds defaulted to 1.0 while repeat_after_count defaulted to 0. Since the two re-benchmark triggers are OR'd, setting only repeat_after_count still left a hidden per-second re-evaluation active, which was unintuitive.

Both now default to None ("unset"); a value <= 0 means explicitly disabled. When both are left unset, perf_dispatch picks an internal default of repeat_after_count=300 with no time-based trigger. Passing only one leaves the other off, so exactly the requested trigger is used.

Update the docstring, the perf_dispatch user guide, and add tests covering the new default and None semantics.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
