### PR TITLE
[AMDGPU] Add force_inline loop_config hint for parallel range-for bodies

### DIFF
--- a/docs/source/user_guide/optimization_passes.md
+++ b/docs/source/user_guide/optimization_passes.md
@@ -79,6 +79,28 @@ All of these are fields of `CompileConfig`, so you set them at `qd.init(...)` (o
 
 For everyday use, leave them at their defaults - they are the best-supported and most reliable configuration. The most common deliberate change is `cfg_optimization=False` when iterating on a kernel whose compile time is in your way.
 
+## Forcing (or preventing) inlining of a parallel range-for body (`qd.amdgpu` only)
+
+On the `qd.amdgpu` backend, the body of a parallel range-for is generated as its own function that the per-thread launcher calls, and LLVM's inliner then decides whether to inline that call into the launcher. Its cost model does not always make the choice you want: a small, hot body carries a different `amdgpu-flat-work-group-size` than the kernel, which skews the estimate and can leave a per-thread call boundary in place; conversely a large body can be inlined in a way that raises register pressure and hurts occupancy.
+
+`qd.loop_config(force_inline=...)` is a per-loop hint that overrides that decision for the **next** parallel range-for:
+
+| Value | Effect |
+|-------|--------|
+| `True` | Force the body to be inlined into the launcher (removes the per-thread call boundary; good for small, call-heavy bodies). |
+| `False` | Force the body to stay a separate call (keeps register pressure down; good for large arithmetic bodies where inlining hurts occupancy). |
+| `None` (default) | Leave the decision to LLVM's inliner cost model. |
+
+```python
+@qd.kernel
+def saxpy(x: qd.types.ndarray(ndim=1), y: qd.types.ndarray(ndim=1), a: qd.f32):
+    qd.loop_config(force_inline=True)
+    for i in range(x.shape[0]):
+        y[i] = a * x[i] + y[i]
+```
+
+This hint is **`qd.amdgpu`-only and a no-op on every other backend**; it applies only to parallel range-for loops (not mesh-for), and does not change results - only the generated call structure. Whether inlining helps is workload-dependent, so treat it as a tuning knob to try both ways under a profiler rather than a guaranteed speedup.
+
 ## Inspecting what the compiler did
 
 These environment variables dump the IR so you can see the effect of each pass. Files are written to the directory set by the `debug_dump_path` option in `qd.init(...)` (default `/tmp/ir/`):

--- a/python/quadrants/lang/misc.py
+++ b/python/quadrants/lang/misc.py
@@ -673,6 +673,13 @@ def _bit_vectorize():
     get_runtime().compiling_callable.ast_builder().bit_vectorize()
 
 
+def _force_inline(v):
+    """Tri-state hint to the AMDGPU codegen force-inline heuristic for the body
+    of the next parallel-range-for. Ignored on non-AMDGPU backends.
+    """
+    get_runtime().compiling_callable.ast_builder().force_inline(int(v))
+
+
 def loop_config(
     *,
     block_dim=None,
@@ -681,6 +688,7 @@ def loop_config(
     block_dim_adaptive=True,
     bit_vectorize=False,
     name=None,
+    force_inline=None,
 ):
     """Sets directives for the next loop
 
@@ -691,6 +699,10 @@ def loop_config(
         block_dim_adaptive (bool): Whether to allow backends set block_dim adaptively, enabled by default
         bit_vectorize (bool): Whether to enable bit vectorization of struct fors on quant_arrays.
         name (str): Optional name for this loop, used in GPU kernel names for profiling and debugging.
+        force_inline (Optional[bool]): AMDGPU-only hint for the parallel-range-for body inlining heuristic.
+            ``True`` forces the body to be inlined into the launcher trampoline (good for call-heavy bodies),
+            ``False`` forces it NOT to be inlined (good for register-pressure-sensitive bodies like large
+            arithmetic kernels), ``None`` (default) uses the size-based heuristic. Ignored on non-AMDGPU.
 
     Examples::
 
@@ -748,6 +760,9 @@ def loop_config(
 
     if name is not None:
         get_runtime().compiling_callable.ast_builder().set_loop_name(name)
+
+    if force_inline is not None:
+        _force_inline(1 if force_inline else -1)
 
 
 def graph_do_while(condition) -> bool:

--- a/quadrants/analysis/gen_offline_cache_key.cpp
+++ b/quadrants/analysis/gen_offline_cache_key.cpp
@@ -382,6 +382,7 @@ class ASTSerializer : public IRVisitor, public ExpressionVisitor {
     emit(stmt->strictly_serialized);
     emit(stmt->mem_access_opt);
     emit(stmt->block_dim);
+    emit(stmt->force_inline);
     // This for-loop's graph-region tags (see emit_graph_region_key): graph_do_while / graph_parallel_context emit no
     // loop IR of their own, so these loose ints are the only record in the key of which loop level / stream_parallel
     // group / region / checkpoint the loop belongs to. Wrap them in a temporary tag so they route through the same

--- a/quadrants/codegen/amdgpu/codegen_amdgpu.cpp
+++ b/quadrants/codegen/amdgpu/codegen_amdgpu.cpp
@@ -272,6 +272,21 @@ class TaskCodeGenAMDGPU : public TaskCodeGenLLVM {
       body = guard.body;
     }
 
+    // ``stmt->force_inline`` comes from ``qd.loop_config(force_inline=...)``:
+    //   +1 -> force-inline the loop body into the launcher trampoline (removes a
+    //         per-thread call boundary in hot loops whose small bodies the AMDGPU
+    //         cost model otherwise declines to inline).
+    //   -1 -> force the body to stay a separate (NoInline) call, e.g. for
+    //         register-pressure-sensitive bodies where inlining hurts occupancy.
+    //    0 (default) -> leave it to LLVM's inliner cost model.
+    if (body) {
+      if (stmt->force_inline > 0) {
+        tlctx->mark_inline(body);
+      } else if (stmt->force_inline < 0) {
+        body->addFnAttr(llvm::Attribute::NoInline);
+      }
+    }
+
     auto epilogue = create_xlogue(stmt->tls_epilogue);
 
     auto [begin, end] = get_range_for_bounds(stmt);

--- a/quadrants/ir/frontend_ir.cpp
+++ b/quadrants/ir/frontend_ir.cpp
@@ -110,6 +110,7 @@ FrontendForStmt::FrontendForStmt(const FrontendForStmt &o)
       strictly_serialized(o.strictly_serialized),
       mem_access_opt(o.mem_access_opt),
       block_dim(o.block_dim),
+      force_inline(o.force_inline),
       stream_parallel_group_id(o.stream_parallel_group_id),
       graph_parallel_region_id(o.graph_parallel_region_id),
       graph_do_while_level_id(o.graph_do_while_level_id),
@@ -122,6 +123,7 @@ void FrontendForStmt::init_config(Arch arch, const ForLoopConfig &config) {
   strictly_serialized = config.strictly_serialized;
   mem_access_opt = config.mem_access_opt;
   block_dim = config.block_dim;
+  force_inline = config.force_inline;
   stream_parallel_group_id = config.stream_parallel_group_id;
   graph_parallel_region_id = config.graph_parallel_region_id;
   graph_do_while_level_id = config.graph_do_while_level_id;

--- a/quadrants/ir/frontend_ir.h
+++ b/quadrants/ir/frontend_ir.h
@@ -23,6 +23,7 @@ struct ForLoopConfig {
   MemoryAccessOptions mem_access_opt;
   int block_dim{0};
   bool uniform{false};
+  int force_inline{0};
   int stream_parallel_group_id{0};
   // Per-kernel id of the enclosing `qd.graph_parallel_context()` region (0 outside any region). Assigned by the AST
   // builder's `current_graph_parallel_region_id_` at `begin_frontend_*_for` time and threaded alongside
@@ -212,6 +213,7 @@ class FrontendForStmt : public Stmt {
   bool strictly_serialized;
   MemoryAccessOptions mem_access_opt;
   int block_dim;
+  int force_inline{0};
   int stream_parallel_group_id{0};
   int graph_parallel_region_id{0};
   int graph_do_while_level_id{-1};
@@ -934,6 +936,7 @@ class ASTBuilder {
       config.mem_access_opt.clear();
       config.block_dim = 0;
       config.strictly_serialized = false;
+      config.force_inline = 0;
       config.stream_parallel_group_id = 0;
       config.graph_parallel_region_id = 0;
       config.graph_do_while_level_id = -1;
@@ -1084,6 +1087,11 @@ class ASTBuilder {
       QD_ASSERT(bit::is_power_of_two(v));
     }
     for_loop_dec_.config.block_dim = v;
+  }
+
+  void force_inline(int v) {
+    QD_ASSERT(v == -1 || v == 0 || v == 1);
+    for_loop_dec_.config.force_inline = v;
   }
 
   void set_loop_name(const std::string &loop_name) {

--- a/quadrants/ir/statements.cpp
+++ b/quadrants/ir/statements.cpp
@@ -227,6 +227,7 @@ std::unique_ptr<Stmt> RangeForStmt::clone() const {
   new_stmt->checkpoint_id = checkpoint_id;
   new_stmt->graph_do_while_level_id = graph_do_while_level_id;
   new_stmt->loop_name = loop_name;
+  new_stmt->force_inline = force_inline;
   return new_stmt;
 }
 
@@ -411,6 +412,7 @@ std::unique_ptr<Stmt> OffloadedStmt::clone() const {
   new_stmt->tls_size = tls_size;
   new_stmt->bls_size = bls_size;
   new_stmt->mem_access_opt = mem_access_opt;
+  new_stmt->force_inline = force_inline;
   new_stmt->stream_parallel_group_id = stream_parallel_group_id;
   new_stmt->graph_parallel_region_id = graph_parallel_region_id;
   new_stmt->checkpoint_id = checkpoint_id;

--- a/quadrants/ir/statements.h
+++ b/quadrants/ir/statements.h
@@ -990,6 +990,10 @@ class RangeForStmt : public Stmt {
   // runtime can reconstruct nested graph_do_while loops. See graph_do_while docs.
   int graph_do_while_level_id{-1};
   std::string loop_name;
+  // Tri-state AMDGPU codegen hint from qd.loop_config(force_inline=...): 0 = size heuristic,
+  // 1 = force-inline the body, -1 = force no-inline. Propagated FrontendForStmt -> RangeForStmt
+  // (lower_ast.cpp) -> OffloadedStmt (offload.cpp), consumed in codegen_amdgpu.cpp. AMDGPU-only.
+  int force_inline{0};
 
   RangeForStmt(Stmt *begin,
                Stmt *end,
@@ -1413,6 +1417,8 @@ class OffloadedStmt : public Stmt {
   std::size_t tls_size{1};  // avoid allocating dynamic memory with 0 byte
   std::size_t bls_size{0};
   MemoryAccessOptions mem_access_opt;
+  // See RangeForStmt::force_inline. Set from the source RangeForStmt in offload.cpp; AMDGPU-only.
+  int force_inline{0};
   int stream_parallel_group_id{0};
   // Per-kernel `qd.graph_parallel_context()` region id (0 outside any region). Set by `offload.cpp` from the source
   // `RangeForStmt` / `StructForStmt`. The CUDA LLVM codegen copies it into `OffloadedTask::graph_parallel_region_id`

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -317,6 +317,7 @@ void export_lang(nb::module_ &m) {
       .def("parallelize", &ASTBuilder::parallelize)
       .def("strictly_serialize", &ASTBuilder::strictly_serialize)
       .def("block_dim", &ASTBuilder::block_dim)
+      .def("force_inline", &ASTBuilder::force_inline)
       .def("insert_snode_access_flag", &ASTBuilder::insert_snode_access_flag)
       .def("reset_snode_access_flag", &ASTBuilder::reset_snode_access_flag)
       .def("begin_stream_parallel", &ASTBuilder::begin_stream_parallel)

--- a/quadrants/transforms/lower_ast.cpp
+++ b/quadrants/transforms/lower_ast.cpp
@@ -273,6 +273,7 @@ class LowerAST : public IRVisitor {
       new_for->graph_parallel_region_id = stmt->graph_parallel_region_id;
       new_for->checkpoint_id = stmt->checkpoint_id;
       new_for->graph_do_while_level_id = stmt->graph_do_while_level_id;
+      new_for->force_inline = stmt->force_inline;
       VecStatement new_statements;
       Stmt *loop_index = new_statements.push_back<LoopIndexStmt>(new_for.get(), 0);
       for (int i = (int)shape.size() - 1; i >= 0; i--) {
@@ -287,6 +288,8 @@ class LowerAST : public IRVisitor {
     } else if (stmt->mesh) {
       auto &&new_for = std::make_unique<MeshForStmt>(stmt->mesh, stmt->element_type, std::move(stmt->body),
                                                      stmt->is_bit_vectorized, stmt->num_cpu_threads, stmt->block_dim);
+      // MeshForStmt does not carry the force_inline hint, so a mesh-for body never gets AlwaysInline on
+      // AMDGPU. If a mesh-for ever needs to opt in, plumb force_inline through MeshForStmt/FrontendForStmt.
       new_for->graph_do_while_level_id = stmt->graph_do_while_level_id;
       new_for->body->insert(std::make_unique<LoopIndexStmt>(new_for.get(), 0), 0);
       new_for->body->local_var_to_stmt[stmt->loop_var_ids[0]] = new_for->body->statements[0].get();
@@ -311,6 +314,7 @@ class LowerAST : public IRVisitor {
         new_for->graph_parallel_region_id = stmt->graph_parallel_region_id;
         new_for->checkpoint_id = stmt->checkpoint_id;
         new_for->graph_do_while_level_id = stmt->graph_do_while_level_id;
+        new_for->force_inline = stmt->force_inline;
         new_for->body->insert(std::make_unique<LoopIndexStmt>(new_for.get(), 0), 0);
         new_for->body->local_var_to_stmt[stmt->loop_var_ids[0]] = new_for->body->statements[0].get();
         fctx.push_back(std::move(new_for));

--- a/quadrants/transforms/offload.cpp
+++ b/quadrants/transforms/offload.cpp
@@ -194,6 +194,7 @@ class Offloader {
           offloaded->body->insert(std::move(s->body->statements[j]));
         }
         offloaded->range_hint = s->range_hint;
+        offloaded->force_inline = s->force_inline;
         offloaded->stream_parallel_group_id = s->stream_parallel_group_id;
         offloaded->graph_parallel_region_id = s->graph_parallel_region_id;
         offloaded->graph_do_while_level_id = s->graph_do_while_level_id;


### PR DESCRIPTION
## Summary
Adds a tri-state `qd.loop_config(force_inline=True/False/None)` hint controlling whether an AMDGPU parallel range-for **body** is inlined into the launcher trampoline:
- `True` → mark the body `alwaysinline` (removes a per-thread call boundary in hot loops whose small bodies the AMDGPU inliner cost model otherwise declines to inline — the body function carries a different `amdgpu-flat-work-group-size` than the kernel, which skews the cost model).
- `False` → mark the body `noinline` (keep it a separate call for register-pressure-sensitive bodies where inlining hurts occupancy).
- `None` (default) → unchanged; LLVM's inliner decides.

The hint is plumbed front-end → `FrontendForStmt` → `RangeForStmt` (`lower_ast`) → `OffloadedStmt` (`offload`) → consumed in `codegen_amdgpu.cpp`. It is **AMDGPU-only and a no-op on other backends**; mesh-for does not carry it. 9 files, +54, all additive.

## Testing
Built and validated on gfx942 (MI300X), `arch=amdgpu`:
- **Correctness**: a `f32` range-for kernel produces identical, correct results with `force_inline` set to `None`, `True`, and `False`.
- **IR**: for otherwise-identical kernels, the loop-body attribute group gains `alwaysinline` under `True`, `noinline` under `False`, and neither under `None` — confirming the hint reaches codegen and takes effect.

Note: the inlining win is workload-dependent; this PR verifies the mechanism (attribute + correctness), not a specific speedup number.

Made with [Cursor](https://cursor.com)