### PR TITLE
[Build] Pin nanobind below 2.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,6 @@ Homepage = "https://github.com/Genesis-Embodied-AI/quadrants"
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    # nanobind bindings (headers + CMake config + nanobind_add_stub).
     # FIXME: drop this bound together with the one in the dev extra above.
     "nanobind>=2.0.0,<2.14.0",
     "numpy>=2.0.0",        # NumPy headers for the extension

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dev = [
     "Pillow",
     # C++ <-> Python bindings (replaced pybind11); ships its own stubgen. 2.14.0 requires __index__ for implicit
     # conversion to int arguments, which numpy.bool no longer provides, so `field[i] = np_bool` stops working.
-    # FIXME: lift the upper bound once lang/field.py coerces numpy scalars before handing them to write_uint.
+    # FIXME: coerce numpy scalars to int in lang/field.py before handing them to write_uint, then drop this bound.
     "nanobind>=2.0.0,<2.14.0",
     "pydantic",
     "GitPython",
@@ -107,7 +107,7 @@ Homepage = "https://github.com/Genesis-Embodied-AI/quadrants"
 requires = [
     "scikit-build-core>=0.10",
     # nanobind bindings (headers + CMake config + nanobind_add_stub).
-    # FIXME: upper bound, see the dev extra above; lift both together.
+    # FIXME: drop this bound together with the one in the dev extra above.
     "nanobind>=2.0.0,<2.14.0",
     "numpy>=2.0.0",        # NumPy headers for the extension
     "setuptools_scm>=6.0", # version from git tags (metadata provider below)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,10 @@ dev = [
     "colorama",
     "coverage",
     "Pillow",
-    "nanobind>=2.0.0",  # C++ <-> Python bindings (replaced pybind11); ships its own stubgen
+    # C++ <-> Python bindings (replaced pybind11); ships its own stubgen. 2.14.0 requires __index__ for implicit
+    # conversion to int arguments, which numpy.bool no longer provides, so `field[i] = np_bool` stops working.
+    # FIXME: lift the upper bound once lang/field.py coerces numpy scalars before handing them to write_uint.
+    "nanobind>=2.0.0,<2.14.0",
     "pydantic",
     "GitPython",
     "yapf",
@@ -103,7 +106,9 @@ Homepage = "https://github.com/Genesis-Embodied-AI/quadrants"
 [build-system]
 requires = [
     "scikit-build-core>=0.10",
-    "nanobind>=2.0.0",     # nanobind bindings (headers + CMake config + nanobind_add_stub)
+    # nanobind bindings (headers + CMake config + nanobind_add_stub).
+    # FIXME: upper bound, see the dev extra above; lift both together.
+    "nanobind>=2.0.0,<2.14.0",
     "numpy>=2.0.0",        # NumPy headers for the extension
     "setuptools_scm>=6.0", # version from git tags (metadata provider below)
 ]


### PR DESCRIPTION
## Summary

`main` is red on Python 3.11+ for every architecture. A single test fails,
`tests/python/test_ast_refactor.py::test_single_compare`:

```
TypeError: write_uint(): incompatible function arguments. The following argument types are supported:
    1. write_uint(self, arg0: collections.abc.Sequence[int], arg1: int, /) -> None

Invoked with types: quadrants._lib.core.quadrants_python.SNodeCxx, tuple, bool
```

Nothing in this repository changed. Two unpinned dependencies intersected:

- **nanobind 2.14.0**, released 2026-08-07: *"Implicit conversion to
  integer-typed arguments now requires that the input implement Python's
  `__index__` protocol."* Our requirement was `nanobind>=2.0.0`, so builds
  picked it up automatically.
- **NumPy >= 2.3** removed `__index__` from `numpy.bool` (deprecated in 2.2).

The test assigns into a field from Python scope with `c[i * 6] = a[i] == b[i]`.
`qd.Vector` stores its entries as a NumPy array, so the comparison yields
`np.False_`, and `SNodeHostAccessor` hands that straight to `write_uint`:

https://github.com/Genesis-Embodied-AI/quadrants/blob/main/python/quadrants/lang/field.py#L751-L755

Python 3.10 escapes because it caps NumPy at 2.2.6, where the deprecated
`__index__` still exists. Confirmed locally:

| NumPy  | `operator.index(np.False_)`                                   |
| ------ | ------------------------------------------------------------- |
| 2.2.6  | returns `0`, with a `DeprecationWarning`                        |
| 2.4.6  | raises `TypeError: 'numpy.bool' object cannot be interpreted as an integer` |

This pins nanobind below 2.14.0 in both places that declare it, and marks both
bounds `FIXME`.

## Why a pin rather than a fix

The pin unblocks CI immediately. The real fix is coercing the NumPy scalar at
the call site in `lang/field.py`, which deserves its own change and its own
test; nanobind considers the old permissive behaviour a bug, so the bound
cannot stay forever. The other half of the nanobind change is latent too:
`np.float32` arguments used to be silently truncated and are now rejected, so
there may be more call sites than this one.

## Evidence it is the nanobind version and nothing else

[#842](https://github.com/Genesis-Embodied-AI/quadrants/pull/842) passed this
same test on 3.11/3.12/3.13 on Aug 6 with the *same* NumPy 2.4.6, built against
nanobind **2.13.0**. On Aug 7 the same test on the same xdist worker in the
same position fails, built against nanobind **2.14.0**. A dry-run resolution of
the new constraint selects 2.13.0.

## Test plan

- [ ] CI green on Python 3.11, 3.12 and 3.13 across cpu, metal, vulkan, and the
      manylinux wheels, which is exactly the set that is currently failing.
- [ ] `test_ast_refactor.py::test_single_compare` passes.
