### PR TITLE
[Bug] cache pure kernels across PyTorch MPS queue addresses

### DIFF
--- a/python/quadrants/lang/_fast_caching/config_hasher.py
+++ b/python/quadrants/lang/_fast_caching/config_hasher.py
@@ -9,7 +9,8 @@ def hash_compile_config() -> str:
     """
     Calculates a hash string for the current compiler config.
 
-    If any value in the compiler config changes, the hash string changes too.
+    If any compilation-relevant value in the compiler config changes, the hash
+    string changes too. Process-local runtime handles are normalized.
 
     Though arguably we might want to blacklist certain keys, such as print_ir_debug,
     which do not affect the compiled kernels, just stuff that gets printed during
@@ -25,6 +26,16 @@ def hash_compile_config() -> str:
         if skip:
             continue
         v = getattr(config, k)
+        if (
+            k == "external_metal_command_queue"
+            and v
+            and config.external_metal_command_queue_is_torch_queue
+        ):
+            # PyTorch's MPS queue has a different address in every process, but
+            # it is a runtime resource rather than a compiler input. Cached
+            # SPIR-V is registered against the current runtime's queue when it
+            # is restored. Keep zero and arbitrary external queues distinct.
+            v = "torch_mps_command_queue"
         config_l.append(f"{k}={v}")
     config_hash = hash_iterable_strings(config_l, separator="\n")
     return config_hash

--- a/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
+++ b/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
@@ -20,3 +20,33 @@ def test_config_hasher():
 
     assert h_base == h_same
     assert h_base != h_diff
+
+
+@test_utils.test()
+def test_config_hasher_normalizes_torch_mps_queue_address():
+    qd_init_same_arch()
+    assert qd.cfg is not None
+
+    qd.cfg.external_metal_command_queue_is_torch_queue = True
+    qd.cfg.external_metal_command_queue = 0x1234
+    h_first_queue = config_hasher.hash_compile_config()
+
+    qd.cfg.external_metal_command_queue = 0x5678
+    h_second_queue = config_hasher.hash_compile_config()
+
+    assert h_first_queue == h_second_queue
+
+    # Arbitrary external queues may belong to a different Metal device, so
+    # their addresses remain part of the identity.
+    qd.cfg.external_metal_command_queue_is_torch_queue = False
+    h_external_queue = config_hasher.hash_compile_config()
+    qd.cfg.external_metal_command_queue = 0x9ABC
+    h_other_external_queue = config_hasher.hash_compile_config()
+    assert h_external_queue != h_other_external_queue
+
+    # A missing queue also keeps its own identity, even if the companion flag
+    # is accidentally set.
+    qd.cfg.external_metal_command_queue_is_torch_queue = True
+    qd.cfg.external_metal_command_queue = 0
+    h_missing_queue = config_hasher.hash_compile_config()
+    assert h_second_queue != h_missing_queue


### PR DESCRIPTION
The fast cache key includes nearly every field from CompileConfig, including the raw external command-queue pointer. However, when quadrants shares the command-queue from pytorch, this pointer is unsuitable as a persistent cache since the pointer points to a process-local address that changes every time the process restarts.
This means an otherwise identical kernel receives a different fast-cache key and needs to do the python AST transformation and lowering even though the generated GPU code is unchanged.

This PR addresses this by normalizing the pointer while hashing the config. Instead of using a value that changes every restart, we use the sentinel str "torch_mps_command_queue" if we infer from the config that the external command queue is explicitly marked as pytorch's queue.  This fixes the caching.

## To reproduce

```python
"""Run the same fast-cached kernel in two fresh processes."""

import subprocess
import sys
import tempfile
import time

# With no cache path, launch this file twice using one fresh shared cache.
if len(sys.argv) == 1:
    with tempfile.TemporaryDirectory(prefix="qd-mps-fastcache-") as cache_dir:
        for _ in range(2):
            subprocess.run([sys.executable, __file__, cache_dir], check=True)
    raise SystemExit

import numpy as np
import torch

import quadrants as qd


@qd.kernel(fastcache=True)
def slow_to_compile(out: qd.types.ndarray(dtype=qd.f32, ndim=1), value: qd.f32) -> None:
    for i in range(out.shape[0]):
        x = 0.0
        # Expanded during compilation to make the cache benefit measurable.
        for _ in qd.static(range(1024)):
            x += value
        out[i] = x


# Each process gets a new queue address but uses the same cache directory.
torch.empty(1, device="mps")
queue = qd.interop.get_mps_command_queue()
assert queue != 0
qd.init(
    arch=qd.metal,
    offline_cache=True,
    offline_cache_file_path=sys.argv[1],
    external_metal_command_queue=queue,
    external_metal_command_queue_is_torch_queue=True,
    unrolling_limit=0,
)

out = qd.ndarray(dtype=qd.f32, shape=(16,))
started = time.perf_counter()
slow_to_compile(out, 7.0)
qd.sync()
elapsed_ms = 1e3 * (time.perf_counter() - started)

np.testing.assert_allclose(out.to_numpy(), 7.0 * 1024)

loaded = slow_to_compile._primal.src_ll_cache_observations.cache_loaded
print(f"queue=0x{queue:x} cache_loaded={loaded} elapsed_ms={elapsed_ms:.1f}")
qd.reset()
```

```
Representative Quadrants 1.2.0 output before the fix:

queue=0x12397f200 cache_loaded=False elapsed_ms=446.4
queue=0x124aeba00 cache_loaded=False elapsed_ms=211.8

After the fix:

queue=0x16205b000 cache_loaded=False elapsed_ms=444.6
queue=0x1239b4a00 cache_loaded=True  elapsed_ms=12.3
```

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
