### PR TITLE
[fastcache] Exclude non-codegen config keys from the fast-cache hash

### DIFF
--- a/docs/source/user_guide/fastcache.md
+++ b/docs/source/user_guide/fastcache.md
@@ -121,7 +121,7 @@ Each compiled artifact is stored under a key derived from all of the following:
 - The **Quadrants version** (`quadrants.__version__`).
 - The **source code** of the kernel function or any `@qd.func` it calls.
 - The **argument types** (e.g. switching from `f32` to `f64`, or changing ndarray dimensionality).
-- The **compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`).
+- The **compilation-relevant parts of the compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`). Options that cannot change the generated code are deliberately excluded, so that toggling them does not force a recompile: the `print_*` and `verbose_*` debug options, the `offline_cache*` options, `debug_dump_path` (only chooses the directory IR dumps are written to) and `cuda_stack_limit` (only sets a CUDA context limit at runtime).
 - **Template parameter values** (since they are baked into the compiled kernel).
 
 When any of these change, the resulting key is different, so a new compilation occurs and a new entry is stored. Previous entries remain on disk - multiple cached versions coexist. You do not need to manually clear the cache when making code changes - the hash mismatch causes a transparent recompilation.

--- a/docs/source/user_guide/fastcache.md
+++ b/docs/source/user_guide/fastcache.md
@@ -122,6 +122,7 @@ Each compiled artifact is stored under a key derived from all of the following:
 - The **source code** of the kernel function or any `@qd.func` it calls.
 - The **argument types** (e.g. switching from `f32` to `f64`, or changing ndarray dimensionality).
 - The **compilation-relevant parts of the compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`).
+- The **device capabilities** of the target GPU (e.g. whether Vulkan/Metal expose 64-bit integers, atomics, or a given subgroup family), since codegen branches on them. This keeps an entry compiled for one device from being reused on another with different capabilities, for example when a cache directory is shared across machines.
 - **Template parameter values** (since they are baked into the compiled kernel).
 
 When any of these change, the resulting key is different, so a new compilation occurs and a new entry is stored. Previous entries remain on disk - multiple cached versions coexist. You do not need to manually clear the cache when making code changes - the hash mismatch causes a transparent recompilation.

--- a/docs/source/user_guide/fastcache.md
+++ b/docs/source/user_guide/fastcache.md
@@ -121,7 +121,7 @@ Each compiled artifact is stored under a key derived from all of the following:
 - The **Quadrants version** (`quadrants.__version__`).
 - The **source code** of the kernel function or any `@qd.func` it calls.
 - The **argument types** (e.g. switching from `f32` to `f64`, or changing ndarray dimensionality).
-- The **compilation-relevant parts of the compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`). Options that cannot change the generated code are deliberately excluded, so that toggling them does not force a recompile: the `print_*` and `verbose_*` debug options, the `offline_cache*` options, `debug_dump_path` (only chooses the directory IR dumps are written to) and `cuda_stack_limit` (only sets a CUDA context limit at runtime).
+- The **compilation-relevant parts of the compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`).
 - **Template parameter values** (since they are baked into the compiled kernel).
 
 When any of these change, the resulting key is different, so a new compilation occurs and a new entry is stored. Previous entries remain on disk - multiple cached versions coexist. You do not need to manually clear the cache when making code changes - the hash mismatch causes a transparent recompilation.

--- a/python/quadrants/lang/_fast_caching/config_hasher.py
+++ b/python/quadrants/lang/_fast_caching/config_hasher.py
@@ -45,3 +45,15 @@ def hash_compile_config() -> str:
         config_l.append(f"{k}={v}")
     config_hash = hash_iterable_strings(config_l, separator="\n")
     return config_hash
+
+
+def hash_device_caps() -> str:
+    """Stable fingerprint of the current device's capabilities.
+
+    The compiler config alone does not identify the target device, but SPIR-V (Vulkan / Metal) and other backends
+    branch codegen on device capabilities (int64 / atomics / subgroup families, wave size, ...). The native offline
+    cache already folds these into its key via get_offline_cache_key_of_device_caps; mixing the same fingerprint into
+    the fast-cache checksum keeps a fast-cache entry written on one device from being reused on another with different
+    caps (e.g. a cache dir shared across machines).
+    """
+    return impl.get_runtime().prog.get_device_caps().hashed_key()

--- a/python/quadrants/lang/_fast_caching/config_hasher.py
+++ b/python/quadrants/lang/_fast_caching/config_hasher.py
@@ -4,20 +4,32 @@ from .hash_utils import hash_iterable_strings
 
 EXCLUDE_PREFIXES = ["_", "offline_cache", "print_", "verbose_"]
 
+# Exact key names that do not feed codegen. Matched by full name rather than by prefix, so that config fields added
+# later under the same prefix (say a new cuda_* compiler option) are not silently dropped from the cache key.
+EXCLUDE_KEYS = {
+    # Destination directory for IR dumps only. Whether anything is dumped is gated on the QD_DUMP_IR env var, which is
+    # not part of the cache key either, so the path cannot influence the generated kernel.
+    "debug_dump_path",
+    # Applied once at runtime via context_set_limit(CU_LIMIT_STACK_SIZE) in llvm_runtime_executor, never read by
+    # codegen.
+    "cuda_stack_limit",
+}
+
 
 def hash_compile_config() -> str:
     """
     Calculates a hash string for the current compiler config.
 
-    If any value in the compiler config changes, the hash string changes too.
-
-    Though arguably we might want to blacklist certain keys, such as print_ir_debug,
-    which do not affect the compiled kernels, just stuff that gets printed during
-    the compilation process.
+    If any compilation-relevant value in the compiler config changes, the hash string changes too. Keys that only
+    affect debug output or runtime device limits are excluded, via EXCLUDE_PREFIXES and EXCLUDE_KEYS, so that they do
+    not cause spurious cache misses. The C++ offline cache key does not include them either, see
+    get_offline_cache_key_of_compile_config in quadrants/analysis/offline_cache_util.cpp.
     """
     config = impl.get_runtime().prog.config()
     config_l = []
     for k in dir(config):
+        if k in EXCLUDE_KEYS:
+            continue
         skip = False
         for prefix in EXCLUDE_PREFIXES:
             if k.startswith(prefix) or k in [""]:

--- a/python/quadrants/lang/_fast_caching/config_hasher.py
+++ b/python/quadrants/lang/_fast_caching/config_hasher.py
@@ -13,6 +13,11 @@ EXCLUDE_KEYS = {
     # Applied once at runtime via context_set_limit(CU_LIMIT_STACK_SIZE) in llvm_runtime_executor, never read by
     # codegen.
     "cuda_stack_limit",
+    # Borrowed MTLCommandQueue* handle, read live from the config by metal_program (device creation) and by
+    # GfxRuntime::submit_current_cmdlist_if_timeout (flush policy), so it is never baked into a compiled kernel. It is
+    # also a process-local address, so hashing it produced a fresh key on every restart and defeated the cache entirely
+    # for shared-queue Metal users.
+    "external_metal_command_queue",
 }
 
 

--- a/python/quadrants/lang/_fast_caching/src_hasher.py
+++ b/python/quadrants/lang/_fast_caching/src_hasher.py
@@ -105,6 +105,7 @@ def create_cache_key(
     - cache value arg values
     - kernel function (but not sub functions)
     - compilation config (which includes arch, and debug)
+    - device capabilities (so a cached entry is not reused on a device whose caps change codegen)
     """
     args_hash = args_hasher.hash_args(raise_on_templated_floats, args, arg_metas)
     if isinstance(args_hash, FastcacheSkip):
@@ -118,12 +119,14 @@ def create_cache_key(
         return None
     kernel_hash = function_hasher.hash_kernel(kernel_source_info)
     config_hash = config_hasher.hash_compile_config()
+    device_caps_hash = config_hasher.hash_device_caps()
     cache_key = hash_iterable_strings(
         (
             quadrants.__version_str__,
             kernel_hash,
             args_hash,
             config_hash,
+            device_caps_hash,
             kernel_source_info.filepath,
             str(kernel_source_info.start_lineno),
             "pruned",

--- a/quadrants/analysis/offline_cache_util.cpp
+++ b/quadrants/analysis/offline_cache_util.cpp
@@ -199,4 +199,14 @@ std::string get_hashed_offline_cache_key(const CompileConfig &config,
   return res;
 }
 
+std::string get_hashed_offline_cache_key_of_device_caps(const DeviceCapabilityConfig &caps) {
+  auto device_caps_key = get_offline_cache_key_of_device_caps(caps);
+  picosha2::hash256_one_by_one hasher;
+  hasher.process(device_caps_key.begin(), device_caps_key.end());
+  hasher.finish();
+  auto res = picosha2::get_hash_hex_string(hasher);
+  res.insert(res.begin(), 'T');  // The key must start with a letter
+  return res;
+}
+
 }  // namespace quadrants::lang

--- a/quadrants/analysis/offline_cache_util.h
+++ b/quadrants/analysis/offline_cache_util.h
@@ -17,6 +17,10 @@ std::string get_hashed_offline_cache_key_of_snode(const SNode *snode);
 std::string get_hashed_offline_cache_key(const CompileConfig &config,
                                          const DeviceCapabilityConfig &caps,
                                          Kernel *kernel);
+// Stable hex fingerprint of the device capabilities alone, using the same serialization that feeds
+// get_hashed_offline_cache_key. Exposed to the Python fast-cache so its checksum can distinguish devices whose caps
+// change the generated code (e.g. SPIR-V int64 / atomics families), matching the caps-awareness of the native cache.
+std::string get_hashed_offline_cache_key_of_device_caps(const DeviceCapabilityConfig &caps);
 void gen_offline_cache_key(IRNode *ast, std::ostream *os);
 
 }  // namespace quadrants::lang

--- a/quadrants/program/compile_config.h
+++ b/quadrants/program/compile_config.h
@@ -50,7 +50,6 @@ struct CompileConfig {
   DataType default_fp;
   DataType default_ip;
   DataType default_up;
-  std::string extra_flags;
   int default_cpu_block_dim;
   bool cpu_block_dim_adaptive;
   int default_gpu_block_dim;

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -327,12 +327,11 @@ void export_lang(nb::module_ &m) {
       .def("begin_checkpoint", &ASTBuilder::begin_checkpoint)
       .def("end_checkpoint", &ASTBuilder::end_checkpoint);
 
-  auto device_capability_config =
-      nb::class_<DeviceCapabilityConfig>(m, "DeviceCapabilityConfig")
-          .def("get", &DeviceCapabilityConfig::get)
-          .def("hashed_key", [](const DeviceCapabilityConfig &caps) {
-            return get_hashed_offline_cache_key_of_device_caps(caps);
-          });
+  auto device_capability_config = nb::class_<DeviceCapabilityConfig>(m, "DeviceCapabilityConfig")
+                                      .def("get", &DeviceCapabilityConfig::get)
+                                      .def("hashed_key", [](const DeviceCapabilityConfig &caps) {
+                                        return get_hashed_offline_cache_key_of_device_caps(caps);
+                                      });
 
   auto compiled_kernel_data = nb::class_<CompiledKernelData>(m, "CompiledKernelData")
                                   .def("_debug_dump_to_string", &CompiledKernelData::debug_dump_to_string);

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -19,6 +19,7 @@
 #include "quadrants/program/extension.h"
 #include "quadrants/program/ndarray.h"
 #include "quadrants/rhi/device_capability.h"
+#include "quadrants/analysis/offline_cache_util.h"
 #include "quadrants/program/matrix.h"
 #include "quadrants/python/export.h"
 #include "quadrants/math/svd.h"
@@ -327,7 +328,11 @@ void export_lang(nb::module_ &m) {
       .def("end_checkpoint", &ASTBuilder::end_checkpoint);
 
   auto device_capability_config =
-      nb::class_<DeviceCapabilityConfig>(m, "DeviceCapabilityConfig").def("get", &DeviceCapabilityConfig::get);
+      nb::class_<DeviceCapabilityConfig>(m, "DeviceCapabilityConfig")
+          .def("get", &DeviceCapabilityConfig::get)
+          .def("hashed_key", [](const DeviceCapabilityConfig &caps) {
+            return get_hashed_offline_cache_key_of_device_caps(caps);
+          });
 
   auto compiled_kernel_data = nb::class_<CompiledKernelData>(m, "CompiledKernelData")
                                   .def("_debug_dump_to_string", &CompiledKernelData::debug_dump_to_string);

--- a/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
+++ b/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
@@ -37,6 +37,14 @@ def test_config_hasher_ignores_debug_and_runtime_only_keys():
     qd.cfg.cuda_stack_limit = 32768
     assert config_hasher.hash_compile_config() == h_base
 
+    # A process-local queue handle, read live by the runtime. Two addresses, and no queue at all, all hash the same.
+    qd.cfg.external_metal_command_queue = 0x1234
+    assert config_hasher.hash_compile_config() == h_base
+    qd.cfg.external_metal_command_queue = 0x5678
+    assert config_hasher.hash_compile_config() == h_base
+    qd.cfg.external_metal_command_queue = 0
+    assert config_hasher.hash_compile_config() == h_base
+
     # A genuine compiler input still changes the hash, so the exclusions above are not masking everything.
     qd.cfg.fast_math = not qd.cfg.fast_math
     assert config_hasher.hash_compile_config() != h_base

--- a/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
+++ b/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
@@ -1,5 +1,6 @@
 import quadrants as qd
 from quadrants._test_tools import qd_init_same_arch
+from quadrants.lang import impl
 from quadrants.lang._fast_caching import config_hasher
 
 from tests import test_utils
@@ -48,3 +49,21 @@ def test_config_hasher_ignores_debug_and_runtime_only_keys():
     # A genuine compiler input still changes the hash, so the exclusions above are not masking everything.
     qd.cfg.fast_math = not qd.cfg.fast_math
     assert config_hasher.hash_compile_config() != h_base
+
+
+@test_utils.test()
+def test_hash_device_caps_is_stable_and_tagged():
+    assert qd.cfg is not None
+
+    qd_init_same_arch()
+    h1 = config_hasher.hash_device_caps()
+    h2 = config_hasher.hash_device_caps()
+
+    # Deterministic for a fixed device, and non-empty.
+    assert h1 == h2
+    assert h1
+
+    # Mixes in exactly the fingerprint the native offline-cache path folds into its own key, so the two caches agree
+    # on device identity. The leading 'T' mirrors get_hashed_offline_cache_key (key must start with a letter).
+    assert h1 == impl.get_runtime().prog.get_device_caps().hashed_key()
+    assert h1.startswith("T")

--- a/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
+++ b/tests/python/quadrants/lang/fast_caching/test_config_hasher.py
@@ -20,3 +20,23 @@ def test_config_hasher():
 
     assert h_base == h_same
     assert h_base != h_diff
+
+
+@test_utils.test()
+def test_config_hasher_ignores_debug_and_runtime_only_keys():
+    assert qd.cfg is not None
+
+    qd_init_same_arch()
+    h_base = config_hasher.hash_compile_config()
+
+    # Only selects where IR dumps are written, and only when QD_DUMP_IR is set.
+    qd.cfg.debug_dump_path = "/tmp/some-other-ir-dump-dir/"
+    assert config_hasher.hash_compile_config() == h_base
+
+    # Only sets a CUDA context limit at runtime.
+    qd.cfg.cuda_stack_limit = 32768
+    assert config_hasher.hash_compile_config() == h_base
+
+    # A genuine compiler input still changes the hash, so the exclusions above are not masking everything.
+    qd.cfg.fast_math = not qd.cfg.fast_math
+    assert config_hasher.hash_compile_config() != h_base

--- a/tests/python/quadrants/lang/fast_caching/test_src_hasher.py
+++ b/tests/python/quadrants/lang/fast_caching/test_src_hasher.py
@@ -47,6 +47,31 @@ def test_src_hasher_create_cache_key_vary_config() -> None:
 
 
 @test_utils.test()
+def test_src_hasher_create_cache_key_varies_with_device_caps(monkeypatch) -> None:
+    # The device-caps fingerprint is plumbed in from config_hasher; stub it so we can exercise the keying without a
+    # second physical device. Same source / args / config but different caps must yield a different cache key, so a
+    # cache dir shared across devices (or machines) cannot serve an artifact compiled for the wrong capabilities.
+    from quadrants.lang._fast_caching import config_hasher
+
+    @qd.kernel
+    def f1() -> None:
+        pass
+
+    qd_init_same_arch(print_ir_dbg_info=False)
+    kernel_info, _src = get_source_info_and_src(f1.fn)
+
+    monkeypatch.setattr(config_hasher, "hash_device_caps", lambda: "caps-A")
+    key_caps_a = src_hasher.create_cache_key(False, kernel_info, [], [])
+    key_caps_a_again = src_hasher.create_cache_key(False, kernel_info, [], [])
+
+    monkeypatch.setattr(config_hasher, "hash_device_caps", lambda: "caps-B")
+    key_caps_b = src_hasher.create_cache_key(False, kernel_info, [], [])
+
+    assert key_caps_a == key_caps_a_again
+    assert key_caps_a != key_caps_b
+
+
+@test_utils.test()
 def test_src_hasher_validate_hashed_function_infos(monkeypatch, tmp_path: pathlib.Path, temporary_module) -> None:
     test_files_path = pathlib.Path("tests/python/quadrants/lang/fast_caching/test_files")
     monkeypatch.syspath_prepend(tmp_path)


### PR DESCRIPTION
## Summary

`hash_compile_config` builds the fast-cache config hash by walking every pybind-exported `CompileConfig` field and
filtering only by prefix (`EXCLUDE_PREFIXES`). That sweeps in knobs which have no influence on generated code, so
changing one of them forces a full Python AST transform and lowering for kernels whose GPU code is byte-identical.

By contrast the C++ offline cache key (`get_offline_cache_key_of_compile_config` in
`quadrants/analysis/offline_cache_util.cpp`) is an explicit allowlist of compilation-relevant fields. This PR moves
three fields on the Python side into an exact-name `EXCLUDE_KEYS` set so the two keys agree:

- `external_metal_command_queue` is a borrowed `MTLCommandQueue*`. Its address is process-local, so hashing it handed
  every restart a different key and no shared-queue Metal process could reuse another's entry. It is read live from the
  config in two places, both at runtime: `metal_program.cpp` when creating the device, and
  `GfxRuntime::submit_current_cmdlist_if_timeout` when deciding whether to force a flush. It is never baked into a
  compiled artifact.
- `debug_dump_path` only chooses the destination directory for IR dumps. Whether anything is dumped at all is gated on
  the `QD_DUMP_IR` env var, which is not part of the cache key either, so the path cannot affect the generated kernel.
- `cuda_stack_limit` is read in exactly one place, `llvm_runtime_executor.cpp`, to call
  `context_set_limit(CU_LIMIT_STACK_SIZE, ...)` at runtime. It never reaches codegen.

Also removes `CompileConfig::extra_flags`, which is declared in `compile_config.h` and never read or written anywhere
in the repo. It is not initialised by the `CompileConfig` constructor and not exported to Python, so nothing can set it.

Matching by exact name rather than by prefix is deliberate: `debug_`, `cuda_` and `external_metal_` happen to match only
these fields today, but a prefix would silently drop any codegen-relevant field added under the same prefix later.
`external_` in particular would wrongly drop `external_optimization_level`, which is a genuine compiler input.

## Relationship to #849

#849 fixes the same `external_metal_command_queue` bug by a narrower route: it rewrites the pointer to a sentinel string
while hashing, but only when `external_metal_command_queue_is_torch_queue` is set, and keeps arbitrary non-PyTorch queue
addresses distinct on the grounds that they may belong to a different Metal device.

This PR excludes the field for all values instead. Device identity does not need the pointer: it is already covered by
`DeviceCapabilityConfig::devcaps`, which is hashed separately into the C++ key. Non-PyTorch external queues (which
`docs/source/user_guide/metal_shared_queue.md` explicitly supports) then get the same cross-process reuse as PyTorch
ones, rather than remaining broken.

The two PRs touch the same lines and will conflict. #849's `test_config_hasher_normalizes_torch_mps_queue_address` also
asserts that two different non-torch queue addresses hash differently, which is the behaviour this PR deliberately
removes, so whichever lands second needs updating.

## Safety

Removing something from a cache key risks stale hits, so worth stating why there is none here. The persisted
`CacheValue` stores source-info hashes, dataclass parameters, `graph_do_while` levels and checkpoint metadata, plus a
nested `frontend_cache_key` which is the C++ key. None of the excluded fields is captured in any of that, and none is in
the C++ key, so no cached artifact can depend on them. All three are read live from the config at runtime, so behaviour
still follows the current process's settings. The direction of the change is over-hashing to correct hashing, where the
failure mode being fixed is a spurious miss rather than a wrong result.

## Test plan

- [ ] New `test_config_hasher_ignores_debug_and_runtime_only_keys` in
      `tests/python/quadrants/lang/fast_caching/test_config_hasher.py` asserts the hash is stable across changes to all
      three excluded fields, and still changes for a genuine compiler input (`fast_math`) so the exclusions are not
      masking everything. It pokes `qd.cfg` directly, so it runs on every backend without special hardware.
- [ ] Full build, to confirm dropping `extra_flags` breaks nothing.
- [ ] End-to-end shared-queue cache reuse needs Metal hardware; the repro in #849 covers it.
