### PR TITLE
[Bug] Disable HIP memory pools on gfx90c where hipMallocAsync hangs.

### DIFF
--- a/docs/source/user_guide/troubleshooting.md
+++ b/docs/source/user_guide/troubleshooting.md
@@ -22,3 +22,22 @@ rm -Rf ~/.cache/quadrants
 If this doesn't solve the problem, then you'll likely need to log a github issue, providing
 as much information as possible, and crucially a minimum reproducible example, to reproduce
 the seg fault.
+
+## AMDGPU hangs on first field allocation
+
+Some APUs (notably Rembrandt `gfx90c`) advertise HIP memory-pool support while `hipMallocAsync`
+never returns. Quadrants then hangs on the first dense field / SNode allocation after
+`qd.init(arch=qd.amdgpu)`.
+
+- On `gfx90c`, HIP memory pools are disabled automatically; allocations use sync `hipMalloc`.
+- To force that path on any AMDGPU device (for example another target with a broken async
+  allocator, or to A/B the pool path):
+
+```bash
+export QD_ENABLE_HIP_MEMPOOL=0
+```
+
+Tradeoff: with pools off, device allocations come from the preallocated arena sized by
+`device_memory_fraction` / `device_memory_GB` in `qd.init(...)`. Large batched scenes may need a
+higher fraction (e.g. `qd.init(..., device_memory_fraction=0.9)`). Kernel speed is unchanged;
+only allocation growth behavior differs.

--- a/quadrants/rhi/amdgpu/amdgpu_context.cpp
+++ b/quadrants/rhi/amdgpu/amdgpu_context.cpp
@@ -8,10 +8,22 @@
 #include "quadrants/system/threading.h"
 #include "quadrants/rhi/amdgpu/amdgpu_driver.h"
 #include "quadrants/rhi/amdgpu/amdgpu_profiler.h"
+#include "quadrants/util/environ_config.h"
 #include "quadrants/util/offline_cache.h"
 
 namespace quadrants {
 namespace lang {
+
+namespace {
+
+// Drivers on some APUs advertise hipDeviceAttributeMemoryPoolsSupported while hipMallocAsync never returns.
+// Do not probe by calling hipMallocAsync in-process: a wedged call can leave the HIP runtime unusable for later
+// hipMalloc in the same process. Gate known-bad targets here instead; expand when more mcpu ids are confirmed.
+bool is_hip_malloc_async_unreliable(const std::string &mcpu) {
+  return mcpu == "gfx90c";
+}
+
+}  // namespace
 
 thread_local void *AMDGPUContext::stream_ = nullptr;
 
@@ -84,19 +96,31 @@ AMDGPUContext::AMDGPUContext() : driver_(AMDGPUDriver::get_instance_without_cont
   // device_memory_GB preallocation, the same way the CUDA backend does via cuMemAllocAsync. This feature requires
   // ROCm >= 5.2; earlier runtimes are not supported by quadrants. Use the non-throwing .call() variant so a future
   // hipDeviceAttribute_t reshuffle degrades to "no pool" rather than aborting init.
-  int device_supports_mem_pool = 0;
-  uint32 attr_err = driver_.device_get_attribute.call(
-      &device_supports_mem_pool, HIP_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED, 0 /*device ordinal*/);
+  //
+  // QD_ENABLE_HIP_MEMPOOL=0 forces the sync hipMalloc path. Known-unreliable mcpu ids (see
+  // is_hip_malloc_async_unreliable) also force the sync path even when the driver advertises pool support.
+  if (get_environ_config("QD_ENABLE_HIP_MEMPOOL", 1) == 0) {
+    QD_TRACE("HIP memory pools disabled by QD_ENABLE_HIP_MEMPOOL=0.");
+  } else if (is_hip_malloc_async_unreliable(mcpu_)) {
+    QD_WARN(
+        "HIP memory pools disabled on {}: hipMallocAsync hangs despite MEMORY_POOLS_SUPPORTED. "
+        "Using hipMalloc.",
+        mcpu_);
+  } else {
+    int device_supports_mem_pool = 0;
+    uint32 attr_err = driver_.device_get_attribute.call(
+        &device_supports_mem_pool, HIP_DEVICE_ATTRIBUTE_MEMORY_POOLS_SUPPORTED, 0 /*device ordinal*/);
 
-  if (attr_err == HIP_SUCCESS && device_supports_mem_pool) {
-    supports_mem_pool_ = true;
-    void *default_mem_pool = nullptr;
-    driver_.device_get_default_mem_pool(&default_mem_pool, 0 /*device ordinal*/);
-    // Match CUDAContext: keep up to 128 MiB cached in the pool between alloc cycles. Larger workloads are served by the
-    // pool growing on demand.
-    constexpr uint64 kMemPoolReleaseThreshold = 128ull * 1024 * 1024;
-    driver_.mem_pool_set_attribute(default_mem_pool, HIP_MEMPOOL_ATTR_RELEASE_THRESHOLD,
-                                   (void *)&kMemPoolReleaseThreshold);
+    if (attr_err == HIP_SUCCESS && device_supports_mem_pool) {
+      supports_mem_pool_ = true;
+      void *default_mem_pool = nullptr;
+      driver_.device_get_default_mem_pool(&default_mem_pool, 0 /*device ordinal*/);
+      // Match CUDAContext: keep up to 128 MiB cached in the pool between alloc cycles. Larger workloads are served by
+      // the pool growing on demand.
+      constexpr uint64 kMemPoolReleaseThreshold = 128ull * 1024 * 1024;
+      driver_.mem_pool_set_attribute(default_mem_pool, HIP_MEMPOOL_ATTR_RELEASE_THRESHOLD,
+                                     (void *)&kMemPoolReleaseThreshold);
+    }
   }
 }
 

--- a/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
+++ b/quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h
@@ -31,8 +31,9 @@ PER_AMDGPU_FUNCTION(memcpy_async, hipMemcpyAsync, void *, void *, std::size_t, u
 PER_AMDGPU_FUNCTION(memcpy_host_to_device_async, hipMemcpyHtoDAsync, void *, void *, std::size_t, void *);
 PER_AMDGPU_FUNCTION(memcpy_device_to_host_async, hipMemcpyDtoHAsync, void *, void *, std::size_t, void *);
 PER_AMDGPU_FUNCTION(malloc, hipMalloc, void **, std::size_t);
-// hipMallocAsync/hipFreeAsync require ROCm >= 5.4; the AMDGPUDriver wrappers fall back to the synchronous variants
-// on devices without memory-pool support.
+// hipMallocAsync/hipFreeAsync require ROCm >= 5.2. AMDGPUDriver wrappers fall back to the synchronous variants when
+// the device does not advertise memory-pool support, when QD_ENABLE_HIP_MEMPOOL=0, or when AMDGPUContext classifies
+// the mcpu as hipMallocAsync-unreliable (e.g. gfx90c).
 PER_AMDGPU_FUNCTION(malloc_async_impl, hipMallocAsync, void **, std::size_t, void *);
 PER_AMDGPU_FUNCTION(malloc_managed, hipMallocManaged, void **, std::size_t, uint32);
 PER_AMDGPU_FUNCTION(memset, hipMemset, void *, uint8, std::size_t);

--- a/tests/python/test_memory.py
+++ b/tests/python/test_memory.py
@@ -50,6 +50,25 @@ def test_sparse_field_with_device_memory_pool():
     assert x[255] == 7
 
 
+@pytest.mark.run_in_serial
+@test_utils.test(arch=qd.amdgpu)
+def test_amdgpu_dense_field_alloc_survives_broken_hip_malloc_async():
+    # Regression: gfx90c APUs advertise MEMORY_POOLS_SUPPORTED but hang forever in hipMallocAsync. Dense field
+    # allocation is the first site that takes the mem-pool path after qd.init; AMDGPUContext must disable pools on
+    # that mcpu (or via QD_ENABLE_HIP_MEMPOOL=0) so this returns. Keep the body tiny for healthy AMDGPU CI.
+    n = 64
+    x = qd.field(qd.f32, shape=(n,))
+
+    @qd.kernel
+    def fill():
+        for i in range(n):
+            x[i] = 1.0
+
+    fill()
+    assert x[0] == 1.0
+    assert x[n - 1] == 1.0
+
+
 @test_utils.test(arch=get_host_arch_list())
 def test_oop_memory_leak():
     @qd.data_oriented


### PR DESCRIPTION
## Summary

Fixes #854.

On Rembrandt APUs (`gfx90c`), the driver sets `hipDeviceAttributeMemoryPoolsSupported=1`, so Quadrants enables `hipMallocAsync`. That call never returns on this device; sync `hipMalloc` works. Genesis `gs.init(backend=gs.amdgpu)` then hangs on the first dense field / SNode allocation (`hello_genesis.py` / `scene.build()`).

This PR:

- Disables HIP mem pools when `mcpu == "gfx90c"` (static gate — do not probe with `hipMallocAsync` in-process; a wedged call can break later `hipMalloc` in the same process).
- Adds `QD_ENABLE_HIP_MEMPOOL=0` to force the sync path on any AMDGPU device.
- Adds a small amdgpu regression test that allocates a dense field and launches a tiny kernel.

Falling back to `hipMalloc` uses the existing preallocated device-memory arena (`device_memory_fraction` / `device_memory_GB`). Kernel performance is unchanged; large batched scenes may need a higher fraction (e.g. `0.9`) once pools are off.

## Why this matters for multi-env simulation on APUs

With the hang fixed, Genesis on this Rembrandt APU can run parallel environments. Throughput (env-steps/s) vs CPU for a Franka + PD-control scene:

<img width="1260" height="728" alt="cpu_vs_amdgpu_env_throughput" src="https://github.com/user-attachments/assets/4c97694f-d156-45db-8f57-9251618d0658" />

Benchmark episode replay on single environment:


<video controls src="https://github.com/user-attachments/assets/87a46332-1c73-4da5-8775-af565957ad38"></video>

- Below ~128 envs, CPU is still faster (fixed device-host overhead dominates on 1–64 envs).
- From **n_envs ≈ 128–2048**, the APU scales better than CPU and wins on aggregate throughput (peak ~392k env-steps/s at 2048; 4096 saturates slightly lower).
- Without this change, `gs.amdgpu` never gets past the first allocation, so none of that multi-env benefit is reachable on `gfx90c`.

## Test plan

- [x] Reproduced hang: `hipMallocAsync` never returns; `hipMalloc` OK; `MEMORY_POOLS_SUPPORTED=1` on gfx90c
- [x] With this build: warning `HIP memory pools disabled on gfx90c...`, then Genesis `hello_genesis.py` completes on `gs.amdgpu`
- [x] Multi-env CPU vs APU sweep (Franka) shows APU crossover at n_envs=128 and scaling through 2048
- [ ] CI: `tests/python/test_memory.py::test_amdgpu_dense_field_alloc_survives_broken_hip_malloc_async` on amdgpu runners
- [ ] Confirm non-gfx90c AMDGPU still enables pools when the attribute says so

## Files

- `quadrants/rhi/amdgpu/amdgpu_context.cpp`
- `quadrants/rhi/amdgpu/amdgpu_driver_functions.inc.h`
- `tests/python/test_memory.py`


## Benchmark script

`cpu_vs_amdgpu_envs.py` — Genesis multi-env CPU vs APU sweep used for the chart above 

[cpu_vs_amdgpu_envs.py](https://github.com/user-attachments/files/30869006/cpu_vs_amdgpu_envs.py)


```bash
# from a Genesis checkout with the ROCm gfx90c venv active
python examples/speed_benchmark/cpu_vs_amdgpu_envs.py \
  --backends cpu amdgpu \
  --envs 1 2 4 8 16 32 64 128 256 512 \
  -s 200 --warmup 50
```
