### PR TITLE
[Lang] Attach only a cheap source header per AST node

### DIFF
--- a/python/quadrants/lang/ast/ast_transformer_utils.py
+++ b/python/quadrants/lang/ast/ast_transformer_utils.py
@@ -35,7 +35,11 @@ class Builder:
             if method is None:
                 error_msg = f'Unsupported node "{node.__class__.__name__}"'
                 raise QuadrantsSyntaxError(error_msg)
-            info = ctx.get_pos_info(node) if isinstance(node, (ast.stmt, ast.expr)) else ""
+            # Attach only the cheap file/line/function header to every IR node. Building the full source-line
+            # hint (get_pos_info) here means running TextWrapper for every AST node of every kernel compilation,
+            # which dominates kernel build time. The full hint is still produced on the actual compile-error path
+            # below (get_pos_info in the except handler), so error messages are unchanged.
+            info = ctx.get_pos_header(node) if isinstance(node, (ast.stmt, ast.expr)) else ""
             with impl.get_runtime().src_info_guard(info):
                 res = method(ctx, node)
                 if not hasattr(node, "violates_pure"):
@@ -401,8 +405,11 @@ class ASTTransformerFuncContext:
         except AttributeError:
             raise QuadrantsNameError(f'Name "{name}" is not defined')
 
+    def get_pos_header(self, node: ast.AST) -> str:
+        return f'File "{self.file}", line {node.lineno + self.lineno_offset}, in {self.func.func.__name__}:\n'
+
     def get_pos_info(self, node: ast.AST) -> str:
-        msg = f'File "{self.file}", line {node.lineno + self.lineno_offset}, in {self.func.func.__name__}:\n'
+        msg = self.get_pos_header(node)
         col_offset = self.indent + node.col_offset
         end_col_offset = self.indent + node.end_col_offset
 


### PR DESCRIPTION
This is change 2 of #804 (@duburcqa), split out on its own so it can land independently of that PR's other change.
The code is Alexis's; this PR adds only the measurement below.

## What

`ASTTransformerBase.__call__` attaches source-position info to every generated IR node, and did so via
`get_pos_info`, which builds a `TextWrapper`-formatted source-line-plus-caret hint. That formatting therefore ran
for every stmt/expr node of every kernel compilation.

The eager per-node path now attaches only the cheap `File "...", line N, in fn` header (`get_pos_header`). The full
hint is still produced on the actual compile-error path -- the `except` handler in the same function calls
`get_pos_info` -- so compile-error messages are unchanged.

## Why split it out

#804 pairs this with an unrelated change to `_inside_class` (replacing an `O(len(sys.modules))` scan with a
`linecache` lookup). The two are independent, and on the workload below only this one matters, so separating them
lets this land on its own merits.

## Impact

Measured on a kernel-build-heavy workload (a qipc solver step, ~130 offloaded tasks), timing the first step after
editing one kernel. Variants were interleaved over a single unchanged build with only this file swapped between
cells, so no rebuild and no exposure to a neighbouring job on the node; each figure is one full cold-warm-edit
cycle against a fresh cache.

| variant | rep 1 | rep 2 |
|---|---|---|
| unpatched | 10.77 s | 10.58 s |
| this PR | 6.54 s | 6.60 s |
| full #804 (this + the `_inside_class` change) | 6.52 s | 6.52 s |

So this change is worth ~4.1 s of the ~4.2 s that #804 delivers here; the `_inside_class` scan is ~0.05 s on this
workload, within noise. #804's own suite-wide measurement attributes most of its win to this change as well
(~-10% of `Scene.build` out of -12.5% combined).

## Testing

`test_exception.py`, `test_syntax_errors.py`, `test_nested_kernel_error.py` and `test_ast_refactor.py` -- the suites
that assert on error-message text -- give 161 passed both with and without the change, on the same build.

Made with [Cursor](https://cursor.com)