### PR TITLE
[Lang] Memoise the per-node source-position banner on the function

### DIFF
--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -186,6 +186,8 @@ class FuncBase:
         self.arg_metas_expanded: list[ArgMetadata] = []
         self.orig_arguments: list[ArgMetadata] = []
         self.return_type = None
+        # Shared by every AST transform of this function; see ASTTransformerFuncContext.get_pos_info.
+        self.pos_info_cache: dict[tuple, str] = {}
 
         self.check_parameter_annotations()
 

--- a/python/quadrants/lang/ast/ast_transformer_utils.py
+++ b/python/quadrants/lang/ast/ast_transformer_utils.py
@@ -402,6 +402,24 @@ class ASTTransformerFuncContext:
             raise QuadrantsNameError(f'Name "{name}" is not defined')
 
     def get_pos_info(self, node: ast.AST) -> str:
+        # Runs for every stmt/expr node of every transform (see ASTTransformerBase.__call__), and the TextWrapper
+        # formatting below dominates the Python side of a kernel build. The same function is transformed once per
+        # inlined call site -- tens of times over -- and each transform re-formats the identical positions, so
+        # memoise on the function rather than on this context, which exists for a single transform.
+        #
+        # The cache lives on the FuncBase because that is what fixes everything the result depends on beyond the
+        # node: `file`, `src`, `indent`, `lineno_offset` and the function name all derive from it and are identical
+        # across its transforms. Scoping it there also keeps it bounded by the function's lifetime and correct
+        # across a module reload, which hands out new FuncBase objects and so a new cache.
+        key = (node.lineno, node.col_offset, node.end_lineno, node.end_col_offset, node.__class__.__name__)
+        cached = self.func.pos_info_cache.get(key)
+        if cached is not None:
+            return cached
+        msg = self._build_pos_info(node)
+        self.func.pos_info_cache[key] = msg
+        return msg
+
+    def _build_pos_info(self, node: ast.AST) -> str:
         msg = f'File "{self.file}", line {node.lineno + self.lineno_offset}, in {self.func.func.__name__}:\n'
         col_offset = self.indent + node.col_offset
         end_col_offset = self.indent + node.end_col_offset


### PR DESCRIPTION
## What

`ASTTransformerBase.__call__` attaches source-position info to every generated IR node via `get_pos_info`, which
`TextWrapper`-formats a source-line-plus-caret hint. That formatting therefore runs for every stmt/expr node of
every kernel compilation, and it dominates the Python side of a kernel build.

A function is transformed once per inlined call site -- tens of times over on a large kernel -- and each transform
re-formats the identical positions. This memoises the result. The string produced is byte-identical, so every
diagnostic that embeds it is unchanged.

The cache lives on the `FuncBase` rather than in a module-level dict, because the `FuncBase` is exactly what fixes
the remaining inputs: `file`, `src`, `indent`, `lineno_offset` and the function name all derive from it and are
identical across its transforms, so the key is just the node's position and type. That also bounds the cache by the
function's lifetime and keeps it correct across a module reload, which hands out new `FuncBase` objects.

## Impact

On a kernel-build-heavy workload (a qipc solver step, ~130 offloaded tasks), timing the first step after editing
one kernel, interleaved over a single unchanged build:

| | rep 1 | rep 2 |
|---|---|---|
| before | 10.22 s | 10.17 s |
| after | 5.60 s | 5.59 s |

`get_pos_info` is called 277k times in that run and the memo serves 97.4% of them.

## Relationship to #804

#804 attacks the same hotspot by attaching only a cheap `File "...", line N` header per node and deferring the full
hint to the compile-error path. That is a smaller change and I tried it first (#857), but it is not
behaviour-preserving: the per-node info is not read only by compile errors, it is embedded in `DebugInfo` and
surfaces in runtime diagnostics. `test_overflow.py` asserts the offending source line appears in the overflow
message and 64 of its cases fail without it:

```
assert 'return a + b' in 'Addition overflow detected in File ".../test_overflow.py", line 64, in foo:\n\n'
```

Memoising avoids that by construction, since the string never changes. `test_overflow.py` is green here.

#804's other change, replacing the `O(len(sys.modules))` scan in `_inside_class` with a `linecache` lookup, is
independent of this and still worth landing on its own.

## Testing

`test_overflow.py`, `test_exception.py`, `test_syntax_errors.py`, `test_nested_kernel_error.py` and
`test_ast_refactor.py` -- the suites that assert on message text -- give 291 passed both with and without the
change, on the same build.

Made with [Cursor](https://cursor.com)