### PR TITLE
[Lang] Allow qd.template and qd.Tensor presence checks in qd.static

### DIFF
--- a/docs/source/user_guide/static.md
+++ b/docs/source/user_guide/static.md
@@ -26,6 +26,8 @@ Because `use_fast_path` is a templated parameter, it is known at compile time. T
 
 Without `qd.static`, the condition would be evaluated at runtime for every thread, which is slower. In addition, the kernel will contain the code for both branches, which will increase register pressure, and likely reduce occupancy.
 
+Identity comparisons (`is` and `is not`) are supported only inside `qd.static()`. This lets a kernel test the identity of a compile-time value, for example `if qd.static(value is not None):`.
+
 ## Loop unrolling
 
 ```python

--- a/docs/source/user_guide/static.md
+++ b/docs/source/user_guide/static.md
@@ -26,7 +26,7 @@ Because `use_fast_path` is a templated parameter, it is known at compile time. T
 
 Without `qd.static`, the condition would be evaluated at runtime for every thread, which is slower. In addition, the kernel will contain the code for both branches, which will increase register pressure, and likely reduce occupancy.
 
-`is None` and `is not None` are supported inside `qd.static()` for direct `qd.template()` and `qd.Tensor` kernel arguments. Other identity comparisons and runtime operands remain unsupported.
+`is None` and `is not None` are supported inside `qd.static()` for direct `qd.Template` and `qd.Tensor` kernel arguments. Other identity comparisons and runtime operands remain unsupported.
 
 ## Loop unrolling
 

--- a/docs/source/user_guide/static.md
+++ b/docs/source/user_guide/static.md
@@ -26,7 +26,7 @@ Because `use_fast_path` is a templated parameter, it is known at compile time. T
 
 Without `qd.static`, the condition would be evaluated at runtime for every thread, which is slower. In addition, the kernel will contain the code for both branches, which will increase register pressure, and likely reduce occupancy.
 
-Identity comparisons (`is` and `is not`) are supported only inside `qd.static()`. This lets a kernel test the identity of a compile-time value, for example `if qd.static(value is not None):`.
+`is None` and `is not None` are supported inside `qd.static()` for direct `qd.template()` and `qd.Tensor` kernel arguments. Other identity comparisons and runtime operands remain unsupported.
 
 ## Loop unrolling
 

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -205,6 +205,8 @@ fill(b)   # ndarray branch
 
 The kernel argument is unwrapped to the bare impl before the template-mapper / AST sees it, so kernel bodies still write `x[i, j]` and pay no per-call cost for the wrapper.
 
+For a parameter annotated `qd.Tensor`, calls to the same kernel may alternate among a wrapper, its bare field or ndarray implementation, and `None`. If callers can pass `None`, guard tensor operations with [`qd.static()`](static.md), for example `if qd.static(x is not None):`; the guarded operations are not traced for the `None` specialization. The parameter remains annotated `qd.Tensor`, and `None` must be passed explicitly.
+
 `qd.Tensor` is also the right annotation when storing a tensor as a `dataclasses.dataclass` member:
 
 ```python

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -940,6 +940,7 @@ class ASTTransformer(Builder):
         if ctx.is_in_static_scope():
             ops = {**ops, **ops_static}
         operands = [node.left.ptr] + [comparator.ptr for comparator in node.comparators]
+        operand_nodes = (node.left, *node.comparators)
         val = True
         for i, node_op in enumerate(node.ops):
             if not ctx.is_in_static_scope() and isinstance(node_op, (ast.Is, ast.IsNot)):
@@ -954,6 +955,34 @@ class ASTTransformer(Builder):
                     raise QuadrantsSyntaxError(f'"{type(node_op).__name__}" is only supported inside `qd.static`.')
                 else:
                     raise QuadrantsSyntaxError(f'"{type(node_op).__name__}" is not supported in Quadrants kernels.')
+            if isinstance(node_op, (ast.Is, ast.IsNot)):
+                name = "is" if isinstance(node_op, ast.Is) else "is not"
+                l_node, r_node = operand_nodes[i : i + 2]
+                if isinstance(r_node, ast.Constant) and r_node.value is None:
+                    template_node = l_node
+                    template_side = "left"
+                elif isinstance(l_node, ast.Constant) and l_node.value is None:
+                    template_node = r_node
+                    template_side = "right"
+                else:
+                    template_node = None
+                    template_side = None
+                template_arg_names = {ctx.func.arg_metas[index].name for index in ctx.template_slot_locations}
+                if (
+                    not ctx.is_kernel
+                    or not isinstance(template_node, ast.Name)
+                    or template_node.id.startswith("__qd_")
+                    or any(template_node.id in scope for scope in ctx.local_scopes[1:])
+                    or template_node.id not in template_arg_names
+                    or template_node.id not in ctx.template_vars
+                ):
+                    raise QuadrantsSyntaxError(
+                        f'Operator "{name}" inside `qd.static` requires a direct `qd.template()` or `qd.Tensor` kernel argument and `None`.'
+                    )
+                if template_side == "left":
+                    l = ctx.template_vars[template_node.id]
+                else:
+                    r = ctx.template_vars[template_node.id]
             val = qd_ops.logical_and(val, op(l, r))
         if not isinstance(val, (bool, np.bool_)):
             val = qd_ops.cast(val, primitive_types.u1)

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -934,13 +934,15 @@ class ASTTransformer(Builder):
         ops_static = {
             ast.In: lambda l, r: l in r,
             ast.NotIn: lambda l, r: l not in r,
+            ast.Is: lambda l, r: l is r,
+            ast.IsNot: lambda l, r: l is not r,
         }
         if ctx.is_in_static_scope():
             ops = {**ops, **ops_static}
         operands = [node.left.ptr] + [comparator.ptr for comparator in node.comparators]
         val = True
         for i, node_op in enumerate(node.ops):
-            if isinstance(node_op, (ast.Is, ast.IsNot)):
+            if not ctx.is_in_static_scope() and isinstance(node_op, (ast.Is, ast.IsNot)):
                 name = "is" if isinstance(node_op, ast.Is) else "is not"
                 raise QuadrantsSyntaxError(f'Operator "{name}" in Quadrants scope is not supported.')
             l = operands[i]

--- a/python/quadrants/lang/kernel.py
+++ b/python/quadrants/lang/kernel.py
@@ -35,6 +35,7 @@ from quadrants._lib.core.quadrants_python import (
     KernelLaunchContext,
 )
 from quadrants._tensor_wrapper import _TENSOR_WRAPPER_TYPES
+from quadrants._tensor_wrapper import Tensor as _TensorClass
 from quadrants.lang import _kernel_impl_dataclass, impl, runtime_ops
 
 # `qd.checkpoint` pause / resume model helpers. See `kernel_checkpoint.py` for the full extracted surface; `Kernel`
@@ -909,38 +910,35 @@ class Kernel(FuncBase):
 
         self.raise_on_templated_floats = config.raise_on_templated_floats
         py_args = self.fuse_args(is_func=False, is_pyfunc=False, py_args=py_args, kwargs=kwargs, global_context=None)
-        # Tensor-wrapper unwrap (stork-17). Substitute each ``qd.Tensor`` instance (including ``VectorTensor`` /
-        # ``MatrixTensor`` subclasses) with its underlying ``Ndarray`` / ``ScalarField`` impl *before* anything
-        # downstream observes the arg tuple — including the autograd tape (uses identity), the template mapper
-        # (cache-keys on ``id(arg)``), ``_extract_arg``, and the AST builder. This guarantees JIT cache stability:
-        # ``id(Tensor(impl))`` differs across constructions, but ``id(impl)`` is stable, so wrapper-or-not yields
-        # identical cache keys.
+        # Tensor-wrapper unwrap (stork-17). Canonicalize ``qd.Tensor`` slots, plus wrapper positions discovered on
+        # the first launch, before the autograd tape and identity-keyed caches observe the arg tuple.
         #
-        # PERF: On first call, record which arg positions are Tensor wrappers. On subsequent calls, skip entirely
-        # (empty indices) or unwrap only the cached positions (no full-arg scan). For a kernel with 30 args and 1
+        # PERF: On first call, record the candidate arg positions. On subsequent calls, skip entirely (empty
+        # candidates) or type-check only the cached positions (no full-arg scan). For a kernel with 30 args and 1
         # Tensor, this reduces per-call type checks from 30 to 1.
         #
-        # Safety of caching: kernel parameter annotations are fixed per position (they come from the function
-        # signature and are stored in ``self.mapper.arguments``). Whether a given position receives a Tensor wrapper
-        # or a bare impl is determined by the caller's annotation pattern, which is stable across calls — a user who
-        # passes ``qd.Tensor(impl)`` at position *i* will do so on every call, because the annotation (``qd.Tensor``,
-        # ``qd.Template``, ``qd.types.ndarray()``, or a dataclass type) doesn't change. The template mapper
-        # enforces a fixed arg count (``len(args) == self.num_args``), so cached indices cannot go out of bounds.
+        # ``qd.Tensor`` slots may alternate wrappers, ``None``, and bare impls, so annotation positions remain
+        # candidates even when the first value is not wrapped. Other annotations retain first-call discovery. The
+        # template mapper enforces a fixed arg count, so cached indices cannot go out of bounds.
         if _tensor_wrapper._any_tensor_constructed:  # pyright: ignore[reportOptionalMemberAccess]
             _indices = self._tensor_unwrap_indices
             if _indices is None:
-                _indices = tuple(i for i, a in enumerate(py_args) if type(a) in _TENSOR_WRAPPER_TYPES)
+                _indices = tuple(
+                    i
+                    for i, (a, m) in enumerate(zip(py_args, self.arg_metas))
+                    if type(a) in _TENSOR_WRAPPER_TYPES or m.annotation is _TensorClass
+                )
                 self._tensor_unwrap_indices = _indices
-                if _indices:
-                    py_args_l = list(py_args)
-                    for i in _indices:
-                        py_args_l[i] = py_args_l[i]._impl  # pyright: ignore[reportAttributeAccessIssue]
-                    py_args = tuple(py_args_l)
-            elif _indices:
-                py_args_l = list(py_args)
+            if _indices:
+                py_args_l = None
                 for i in _indices:
-                    py_args_l[i] = py_args_l[i]._impl  # pyright: ignore[reportAttributeAccessIssue]
-                py_args = tuple(py_args_l)
+                    _arg = py_args[i]
+                    if type(_arg) in _TENSOR_WRAPPER_TYPES:
+                        if py_args_l is None:
+                            py_args_l = list(py_args)
+                        py_args_l[i] = _arg._impl
+                if py_args_l is not None:
+                    py_args = tuple(py_args_l)
 
         # Transform the primal kernel to forward mode grad kernel
         # then recover to primal when exiting the forward mode manager

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -159,6 +159,22 @@ def test_static_in():
 
 
 @test_utils.test()
+def test_static_is():
+    @qd.kernel
+    def foo(a: qd.template()) -> qd.i32:
+        b = 0
+        if qd.static(a is None):
+            b = 1
+        elif qd.static(a is not None):
+            b = 2
+        return b
+
+    assert foo(None) == 1
+    assert foo(0) == 2
+    assert foo(qd.i32) == 2
+
+
+@test_utils.test()
 def test_non_static_in():
     with pytest.raises(qd.QuadrantsCompilationError, match='"In" is only supported inside `qd.static`.'):
 

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -175,6 +175,80 @@ def test_static_is():
 
 
 @test_utils.test()
+def test_static_is_rejects_runtime_operands():
+    @qd.kernel
+    def scalar(value: qd.i32) -> qd.i32:
+        return 1 if qd.static(value is None) else 0
+
+    with pytest.raises(
+        qd.QuadrantsSyntaxError,
+        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+    ):
+        scalar(0)
+
+    @qd.kernel
+    def array(value: qd.types.ndarray()) -> qd.i32:
+        return 1 if qd.static(value is not None) else 0
+
+    value = qd.ndarray(qd.i32, shape=(1,))
+    with pytest.raises(
+        qd.QuadrantsSyntaxError,
+        match=r'Operator "is not" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+    ):
+        array(value)
+
+    @qd.kernel
+    def reserved_name(__qd_value: qd.template()) -> qd.i32:
+        return 1 if qd.static(__qd_value is None) else 0
+
+    with pytest.raises(
+        qd.QuadrantsSyntaxError,
+        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+    ):
+        reserved_name(None)
+
+    @qd.kernel
+    def shadowed_template(value: qd.template()) -> qd.i32:
+        result = 0
+        for value in qd.static([None]):
+            result = 1 if qd.static(value is None) else 0
+        return result
+
+    with pytest.raises(
+        qd.QuadrantsSyntaxError,
+        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+    ):
+        shadowed_template(7)
+
+
+@test_utils.test()
+def test_static_is_accepts_tensor_presence():
+    @qd.kernel
+    def present(value: qd.Tensor) -> qd.i32:
+        return 1 if qd.static(value is not None) else 0
+
+    field = qd.field(qd.i32, shape=(1,))
+    array = qd.ndarray(qd.i32, shape=(1,))
+
+    assert present(None) == 0
+    assert present(field) == 1
+    assert present(array) == 1
+
+
+@test_utils.test()
+def test_static_is_rejects_non_none_identity():
+    @qd.kernel
+    def same(value: qd.template()) -> qd.i32:
+        return 1 if qd.static(value is qd.i32) else 0
+
+    with pytest.raises(
+        qd.QuadrantsSyntaxError,
+        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+    ):
+        same(qd.i32)
+
+
+@test_utils.test()
 def test_non_static_in():
     with pytest.raises(qd.QuadrantsCompilationError, match='"In" is only supported inside `qd.static`.'):
 

--- a/tests/python/test_deprecation.py
+++ b/tests/python/test_deprecation.py
@@ -6,14 +6,22 @@ from tests import test_utils
 
 
 @test_utils.test()
-def test_remove_is_is_not():
+def test_is_is_not_unsupported_in_quadrants_scope():
     with pytest.raises(qd.QuadrantsSyntaxError, match='Operator "is" in Quadrants scope is not supported'):
 
         @qd.kernel
-        def func():
-            qd.static(1 is 2)
+        def func_is(a: qd.template()):
+            a is None
 
-        func()
+        func_is(None)
+
+    with pytest.raises(qd.QuadrantsSyntaxError, match='Operator "is not" in Quadrants scope is not supported'):
+
+        @qd.kernel
+        def func_is_not(a: qd.template()):
+            a is not None
+
+        func_is_not(None)
 
 
 @test_utils.test(arch=[qd.cpu, qd.cuda, qd.amdgpu])

--- a/tests/python/test_tensor_annotation.py
+++ b/tests/python/test_tensor_annotation.py
@@ -168,6 +168,82 @@ def test_tensor_layouts_keep_separate_cache_entries():
     assert len(k._primal.mapper.mapping) == 2
 
 
+# ----------------------------------------------------------------------------
+# Alternating values at a qd.Tensor slot
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("later_kind", ["none", "bare"])
+@test_utils.test()
+def test_tensor_slot_cached_wrapper_accepts_none_or_bare_impl(later_kind):
+    out = qd.ndarray(qd.f32, shape=(4,))
+    bias = qd.ndarray(qd.f32, shape=(4,))
+    bias.from_numpy(np.full(4, 100.0, dtype=np.float32))
+
+    @qd.kernel
+    def add_bias(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor):
+        for i in range(out.shape[0]):
+            if qd.static(bias is not None):
+                out[i] = qd.f32(i) + bias[i]
+            else:
+                out[i] = qd.f32(i)
+
+    bias_wrapper = qd.wrap(bias)
+    add_bias(out, bias_wrapper)
+    later = None if later_kind == "none" else bias
+    add_bias(out, later)
+
+    expected = np.arange(4, dtype=np.float32)
+    if later is not None:
+        expected += 100.0
+    np.testing.assert_array_equal(out.to_numpy(), expected)
+
+    add_bias(out, bias_wrapper)
+    np.testing.assert_array_equal(out.to_numpy(), np.arange(4, dtype=np.float32) + 100.0)
+    assert len(add_bias._primal.mapper.mapping) == (2 if later is None else 1)
+
+
+@test_utils.test(arch=[qd.cpu, qd.cuda, qd.amdgpu, qd.metal], require=qd.extension.adstack)
+def test_tensor_slot_none_then_wrapper_survives_tape_replay():
+    bias = qd.ndarray(qd.f32, shape=(4,), needs_grad=True)
+    loss = qd.ndarray(qd.f32, shape=(), needs_grad=True)
+    bias.from_numpy(np.array([3.0, 0.0, 0.0, 0.0], dtype=np.float32))
+
+    @qd.kernel
+    def pick_first(loss: qd.types.NDArray[qd.f32, None], bias: qd.Tensor):
+        if qd.static(bias is not None):
+            loss[None] = bias[0] * 2.0
+
+    bias_wrapper = qd.wrap(bias)
+
+    with qd.ad.Tape(loss=loss):
+        pick_first(loss, None)
+        pick_first(loss, bias_wrapper)
+        pick_first(loss, None)
+
+    np.testing.assert_allclose(loss.to_numpy(), 6.0)
+    np.testing.assert_allclose(bias.grad.to_numpy(), [2.0, 0.0, 0.0, 0.0])
+    assert len(pick_first._primal.mapper.mapping) == 2
+
+
+@test_utils.test()
+def test_tensor_slot_later_wrapper_uses_impl_identity_cache():
+    out = qd.ndarray(qd.f32, shape=(4,))
+    bias = qd.ndarray(qd.f32, shape=(4,))
+    bias_wrapper = qd.wrap(bias)
+
+    @qd.kernel
+    def copy(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor):
+        for i in range(out.shape[0]):
+            out[i] = bias[i]
+
+    copy(out, bias)
+    cache_size = len(copy._primal.mapper._mapping_cache)
+    copy(out, bias_wrapper)
+
+    assert len(copy._primal.mapper._mapping_cache) == cache_size
+
+
 # Vector / matrix element types: qd.Tensor must dispatch the compound-element tensors built by qd.Vector.tensor /
 # qd.Matrix.tensor on both backends.
 


### PR DESCRIPTION
Issue: #856

### Brief Summary

Allow direct `qd.Template` and `qd.Tensor` kernel arguments to use `is None` and `is not None` inside `qd.static()`. Runtime operands and other identity comparisons remain unsupported. For `qd.Tensor` slots, cached wrapper handling now tolerates alternating wrappers, bare field or ndarray values, and `None`.

### Walkthrough

- Evaluate template and Tensor presence from the specialization value.
- Reject runtime operands, aliases, shadowed names, non-`None` identity targets, and use from `qd.func`.
- Cache exact `qd.Tensor` annotation positions as wrapper candidates and unwrap only live wrappers.
- Document and test wrapper, bare-value, and `None` alternation.
- Preserve the existing syntax errors outside `qd.static()`.

Validation: focused Metal cases (9 passed); compare and deprecation tests on arm64 and Metal (24 passed); compatible tensor-annotation tests on Metal (12 passed, 9 skipped, 4 deselected); adjacent launch, cache, and autodiff tests (45 passed, 34 skipped, 1 deselected); documentation checks and full pre-commit passed.
