### PR TITLE
[Bug] Fix alternating qd.Tensor wrapper unwrapping

### DIFF
--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -205,6 +205,8 @@ fill(b)   # ndarray branch
 
 The kernel argument is unwrapped to the bare impl before the template-mapper / AST sees it, so kernel bodies still write `x[i, j]` and pay no per-call cost for the wrapper.
 
+For a parameter annotated `qd.Tensor`, calls to the same kernel may alternate among a `qd.Tensor` wrapper, its bare field or ndarray implementation, and `None`. If callers can pass `None`, guard tensor operations with a compile-time presence check such as `if qd.static(x):`; the guarded operations are not traced for the `None` specialization. The parameter remains annotated `qd.Tensor`, and `None` must be passed explicitly.
+
 `qd.Tensor` is also the right annotation when storing a tensor as a `dataclasses.dataclass` member:
 
 ```python

--- a/python/quadrants/lang/kernel.py
+++ b/python/quadrants/lang/kernel.py
@@ -929,15 +929,16 @@ class Kernel(FuncBase):
                     if type(a) in _TENSOR_WRAPPER_TYPES or m.annotation is _TensorClass
                 )
                 self._tensor_unwrap_indices = _indices
-            py_args_l = None
-            for i in _indices:
-                _arg = py_args[i]
-                if type(_arg) in _TENSOR_WRAPPER_TYPES:
-                    if py_args_l is None:
-                        py_args_l = list(py_args)
-                    py_args_l[i] = _arg._impl
-            if py_args_l is not None:
-                py_args = tuple(py_args_l)
+            if _indices:
+                py_args_l = None
+                for i in _indices:
+                    _arg = py_args[i]
+                    if type(_arg) in _TENSOR_WRAPPER_TYPES:
+                        if py_args_l is None:
+                            py_args_l = list(py_args)
+                        py_args_l[i] = _arg._impl
+                if py_args_l is not None:
+                    py_args = tuple(py_args_l)
 
         # Transform the primal kernel to forward mode grad kernel
         # then recover to primal when exiting the forward mode manager

--- a/python/quadrants/lang/kernel.py
+++ b/python/quadrants/lang/kernel.py
@@ -35,6 +35,7 @@ from quadrants._lib.core.quadrants_python import (
     KernelLaunchContext,
 )
 from quadrants._tensor_wrapper import _TENSOR_WRAPPER_TYPES
+from quadrants._tensor_wrapper import Tensor as _TensorClass
 from quadrants.lang import _kernel_impl_dataclass, impl, runtime_ops
 
 # `qd.checkpoint` pause / resume model helpers. See `kernel_checkpoint.py` for the full extracted surface; `Kernel`
@@ -909,37 +910,33 @@ class Kernel(FuncBase):
 
         self.raise_on_templated_floats = config.raise_on_templated_floats
         py_args = self.fuse_args(is_func=False, is_pyfunc=False, py_args=py_args, kwargs=kwargs, global_context=None)
-        # Tensor-wrapper unwrap (stork-17). Substitute each ``qd.Tensor`` instance (including ``VectorTensor`` /
-        # ``MatrixTensor`` subclasses) with its underlying ``Ndarray`` / ``ScalarField`` impl *before* anything
-        # downstream observes the arg tuple — including the autograd tape (uses identity), the template mapper
-        # (cache-keys on ``id(arg)``), ``_extract_arg``, and the AST builder. This guarantees JIT cache stability:
-        # ``id(Tensor(impl))`` differs across constructions, but ``id(impl)`` is stable, so wrapper-or-not yields
-        # identical cache keys.
+        # Tensor-wrapper unwrap (stork-17). Canonicalize ``qd.Tensor`` slots, plus wrapper positions discovered on
+        # the first launch, before the autograd tape and identity-keyed caches observe the arg tuple.
         #
-        # PERF: On first call, record which arg positions are Tensor wrappers. On subsequent calls, skip entirely
-        # (empty indices) or unwrap only the cached positions (no full-arg scan). For a kernel with 30 args and 1
+        # PERF: On first call, record the candidate arg positions. On subsequent calls, skip entirely (empty
+        # candidates) or type-check only the cached positions (no full-arg scan). For a kernel with 30 args and 1
         # Tensor, this reduces per-call type checks from 30 to 1.
         #
-        # Safety of caching: kernel parameter annotations are fixed per position (they come from the function
-        # signature and are stored in ``self.mapper.arguments``). Whether a given position receives a Tensor wrapper
-        # or a bare impl is determined by the caller's annotation pattern, which is stable across calls — a user who
-        # passes ``qd.Tensor(impl)`` at position *i* will do so on every call, because the annotation (``qd.Tensor``,
-        # ``qd.Template``, ``qd.types.ndarray()``, or a dataclass type) doesn't change. The template mapper
-        # enforces a fixed arg count (``len(args) == self.num_args``), so cached indices cannot go out of bounds.
+        # ``qd.Tensor`` slots may alternate wrappers, ``None``, and bare impls, so annotation positions remain
+        # candidates even when the first value is not wrapped. Other annotations retain first-call discovery. The
+        # template mapper enforces a fixed arg count, so cached indices cannot go out of bounds.
         if _tensor_wrapper._any_tensor_constructed:  # pyright: ignore[reportOptionalMemberAccess]
             _indices = self._tensor_unwrap_indices
             if _indices is None:
-                _indices = tuple(i for i, a in enumerate(py_args) if type(a) in _TENSOR_WRAPPER_TYPES)
+                _indices = tuple(
+                    i
+                    for i, (a, m) in enumerate(zip(py_args, self.arg_metas))
+                    if type(a) in _TENSOR_WRAPPER_TYPES or m.annotation is _TensorClass
+                )
                 self._tensor_unwrap_indices = _indices
-                if _indices:
-                    py_args_l = list(py_args)
-                    for i in _indices:
-                        py_args_l[i] = py_args_l[i]._impl  # pyright: ignore[reportAttributeAccessIssue]
-                    py_args = tuple(py_args_l)
-            elif _indices:
-                py_args_l = list(py_args)
-                for i in _indices:
-                    py_args_l[i] = py_args_l[i]._impl  # pyright: ignore[reportAttributeAccessIssue]
+            py_args_l = None
+            for i in _indices:
+                _arg = py_args[i]
+                if type(_arg) in _TENSOR_WRAPPER_TYPES:
+                    if py_args_l is None:
+                        py_args_l = list(py_args)
+                    py_args_l[i] = _arg._impl
+            if py_args_l is not None:
                 py_args = tuple(py_args_l)
 
         # Transform the primal kernel to forward mode grad kernel

--- a/tests/python/test_tensor_annotation.py
+++ b/tests/python/test_tensor_annotation.py
@@ -168,6 +168,75 @@ def test_tensor_layouts_keep_separate_cache_entries():
     assert len(k._primal.mapper.mapping) == 2
 
 
+# ----------------------------------------------------------------------------
+# Alternating values at a qd.Tensor slot
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("later_kind", ["none", "bare"])
+@test_utils.test()
+def test_tensor_slot_cached_wrapper_accepts_none_or_bare_impl(later_kind):
+    out = qd.ndarray(qd.f32, shape=(4,))
+    bias = qd.ndarray(qd.f32, shape=(4,))
+    bias.from_numpy(np.full(4, 100.0, dtype=np.float32))
+
+    @qd.kernel
+    def add_bias(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor):
+        for i in range(out.shape[0]):
+            if qd.static(bias):
+                out[i] = qd.f32(i) + bias[i]
+            else:
+                out[i] = qd.f32(i)
+
+    add_bias(out, qd.Tensor(bias))
+    later = None if later_kind == "none" else bias
+    add_bias(out, later)
+
+    expected = np.arange(4, dtype=np.float32)
+    if later is not None:
+        expected += 100.0
+    np.testing.assert_array_equal(out.to_numpy(), expected)
+
+
+@test_utils.test(arch=[qd.cpu, qd.cuda, qd.amdgpu, qd.metal], require=qd.extension.adstack)
+def test_tensor_slot_none_then_wrapper_survives_tape_replay():
+    bias = qd.ndarray(qd.f32, shape=(4,), needs_grad=True)
+    loss = qd.ndarray(qd.f32, shape=(), needs_grad=True)
+    bias.from_numpy(np.array([3.0, 0.0, 0.0, 0.0], dtype=np.float32))
+
+    @qd.kernel
+    def pick_first(loss: qd.types.NDArray[qd.f32, None], bias: qd.Tensor):
+        if qd.static(bias):
+            loss[None] = bias[0] * 2.0
+
+    bias_wrapper = qd.Tensor(bias)
+
+    with qd.ad.Tape(loss=loss):
+        pick_first(loss, None)
+        pick_first(loss, bias_wrapper)
+
+    np.testing.assert_allclose(loss.to_numpy(), 6.0)
+    np.testing.assert_allclose(bias.grad.to_numpy(), [2.0, 0.0, 0.0, 0.0])
+
+
+@test_utils.test()
+def test_tensor_slot_later_wrapper_uses_impl_identity_cache():
+    out = qd.ndarray(qd.f32, shape=(4,))
+    bias = qd.ndarray(qd.f32, shape=(4,))
+    bias_wrapper = qd.Tensor(bias)
+
+    @qd.kernel
+    def copy(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor):
+        for i in range(out.shape[0]):
+            out[i] = bias[i]
+
+    copy(out, bias)
+    cache_size = len(copy._primal.mapper._mapping_cache)
+    copy(out, bias_wrapper)
+
+    assert len(copy._primal.mapper._mapping_cache) == cache_size
+
+
 # Vector / matrix element types: qd.Tensor must dispatch the compound-element tensors built by qd.Vector.tensor /
 # qd.Matrix.tensor on both backends.
 


### PR DESCRIPTION
Issue: #856

### Brief Summary

`Kernel.__call__` caches wrapper positions on the first launch and assumes those positions always hold a `qd.Tensor` wrapper. A later `None` or bare field/ndarray implementation can therefore fail while accessing `._impl`, while a wrapper first seen after an unwrapped value can bypass canonicalization. Cache exact `qd.Tensor` annotation positions as candidates and unwrap only exact Tensor wrapper types. Canonicalization remains before autodiff recording, template mapping, and AST construction.

This correction is separate from #859. It does not change static identity checks, fastcache serialization, accepted annotations, or kernel defaults.

### Walkthrough

- Seed candidate positions from exact `qd.Tensor` annotations while retaining wrappers found in other slots on the first launch.
- Check each candidate's runtime type before reading `._impl`, so wrappers, `None`, and bare implementations may alternate.
- Add focused coverage for wrapper-to-`None`, wrapper-to-bare, `None`-to-wrapper Tape replay, and mapper identity stability.
- Document alternating wrapper, bare implementation, and `None` calls for `qd.Tensor` parameters.

Validation: the four focused cases pass on Metal; the same cases produce four causal failures on exact base `ab9a58ab5`. The compatible tensor-annotation selection reports 12 passed, 9 skipped, and 4 deselected; adjacent kernel, template, and cache tests report 38 passed and 8 skipped; adjacent autodiff tests report 89 passed and 9 skipped; full pre-commit passes. CPU testing is unavailable on this host because both the exact base and this commit hit the existing LLVM `Unsupported stack probing method` failure before the focused assertions.

Performance: A controlled, interleaved Metal launch microbenchmark found overlapping retained fresh-process median ranges on the changed launch path. The one-wrapper ranges were 11.78 to 11.90 microseconds for this commit and 11.77 to 11.85 microseconds for the base; the eight-wrapper ranges were 13.56 to 13.73 and 13.55 to 13.73 microseconds. On Genesis `7fb4614`'s anymal workload, an instrumented same-scene Metal/ndarray crossover swapped only the exact `Kernel.__call__` method after fixed untimed cache settlement. The candidate-over-base effect was +1.6082369%; the two-sided t(15) 95% CI was -0.2411585% to +3.4919176%. Across 16 predeclared, counterbalanced `ABBA|BAAB` superblocks, all 128/128 timed windows were clean, covering 524,288 timed steps with no exclusions or reruns. The lower endpoint clears the predeclared -0.50% non-inferiority margin. This is model-based evidence for this scene and host, not an official Genesis benchmark or evidence of a speedup. The unmodified benchmark cannot initialize a display context on this headless macOS host, so the run used only a display-only in-memory `Rasterizer.build` bypass; physics, stepping, control, benchmark timing logic, and tracked source were unchanged.
