### PR TITLE
[Caching] Assign global-temp offsets in a content-keyed order

### DIFF
--- a/quadrants/transforms/offload.cpp
+++ b/quadrants/transforms/offload.cpp
@@ -7,7 +7,13 @@
 
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <vector>
+#include <algorithm>
+#include <typeinfo>
+#include <cstdint>
+#include <string>
 
 namespace quadrants::lang {
 
@@ -454,10 +460,55 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
       return;
     if ((config_.arch == Arch::vulkan || config_.arch == Arch::metal) && demotable_axis_load(stmt))
       return;
-    // Not yet allocated
-    if (local_to_global_.find(top_level_ptr) == local_to_global_.end()) {
-      local_to_global_[top_level_ptr] = allocate_global(top_level_ptr->ret_type);
+    // Collect (dedup, in traversal order) the cross-offload value. Offset assignment is deferred to assign_offsets()
+    // so it can be done in a stable content-keyed order (S2a') rather than traversal order.
+    if (!value_seen_.count(top_level_ptr)) {
+      value_seen_.insert(top_level_ptr);
+      ordered_values_.push_back(top_level_ptr);
     }
+  }
+
+  // Recursive, offset-free content hash over the value's operand-def DAG: a value's key depends on WHAT it is
+  // (statement kind, type, constant/arg identity, operand structure), not on offload traversal order. Memoized (also
+  // dedups shared subexpressions). Used to order global-temp slot assignment stably (S2a').
+  std::uint64_t stable_key(Stmt *s) {
+    if (s == nullptr)
+      return 0;
+    auto it = key_memo_.find(s);
+    if (it != key_memo_.end())
+      return it->second;
+    key_memo_[s] = 1;  // cycle guard; SSA def DAG is acyclic so this is only defensive
+    auto hstr = [](const std::string &str) {
+      std::uint64_t h = 1469598103934665603ULL;
+      for (unsigned char c : str)
+        h = (h ^ c) * 1099511628211ULL;
+      return h;
+    };
+    auto mix = [](std::uint64_t h, std::uint64_t x) { return (h ^ x) * 1099511628211ULL; };
+    std::uint64_t h = hstr(typeid(*s).name());
+    h = mix(h, hstr(s->ret_type.to_string()));
+    if (auto *c = s->cast<ConstStmt>())
+      h = mix(h, hstr(c->val.stringify()));
+    if (auto *a = s->cast<ArgLoadStmt>()) {
+      for (int id : a->arg_id)
+        h = mix(h, (std::uint64_t)(unsigned)id);
+      h = mix(h, (std::uint64_t)a->is_ptr);
+    }
+    for (auto *op : s->get_operands())
+      h = mix(h, stable_key(op));
+    key_memo_[s] = h;
+    return h;
+  }
+
+  // Assign a global-temp offset to every collected cross-offload value, reusing allocate_global's sizing/alignment
+  // verbatim. Values are ordered by stable_key first (stable_sort keeps traversal order among equal keys), so a
+  // slot's offset is a function of its content rather than of traversal order -- which is what keeps a task's IR,
+  // and therefore its cache key, stable across edits elsewhere in the kernel.
+  void assign_offsets() {
+    std::stable_sort(ordered_values_.begin(), ordered_values_.end(),
+                     [this](Stmt *a, Stmt *b) { return stable_key(a) < stable_key(b); });
+    for (auto *v : ordered_values_)
+      local_to_global_[v] = allocate_global(v->ret_type);
   }
 
   void generic_visit(Stmt *stmt) {
@@ -482,6 +533,7 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
                              OffloadedRanges *offloaded_ranges) {
     IdentifyValuesUsedInOtherOffloads pass(config, stmt_to_offloaded, offloaded_ranges);
     root->accept(&pass);
+    pass.assign_offsets();
     return pass.local_to_global_;
   }
 
@@ -493,6 +545,10 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   StmtToOffsetMap local_to_global_;
   Stmt *current_offloaded_;
   std::size_t global_offset_;
+  // Cross-offload values in first-encounter (traversal) order, offset assignment deferred to assign_offsets().
+  std::vector<Stmt *> ordered_values_;
+  std::unordered_set<Stmt *> value_seen_;
+  std::unordered_map<Stmt *, std::uint64_t> key_memo_;
 };
 
 // Store intermediate values to globals so that statements in later offloaded

--- a/quadrants/transforms/offload.cpp
+++ b/quadrants/transforms/offload.cpp
@@ -492,6 +492,25 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
         h = mix(h, (std::uint64_t)(unsigned)id);
       h = mix(h, (std::uint64_t)a->is_ptr);
     }
+    // Semantic discriminant fields: statements of the same class, return type, and operands can still differ in
+    // an op_type (or cast target / bit-vectorization flag). Without these, e.g. a + b and a - b hash equal and
+    // stable_sort falls back to traversal order for them, reintroducing exactly the offset instability this
+    // content-keyed ordering exists to remove (PR #864 review r3776549281).
+    if (auto *u = s->cast<UnaryOpStmt>()) {
+      h = mix(h, (std::uint64_t)u->op_type);
+      if (u->is_cast())
+        h = mix(h, hstr(u->cast_type.to_string()));
+    }
+    if (auto *b = s->cast<BinaryOpStmt>()) {
+      h = mix(h, (std::uint64_t)b->op_type);
+      h = mix(h, (std::uint64_t)b->is_bit_vectorized);
+    }
+    if (auto *t = s->cast<TernaryOpStmt>())
+      h = mix(h, (std::uint64_t)t->op_type);
+    if (auto *a = s->cast<AtomicOpStmt>())
+      h = mix(h, (std::uint64_t)a->op_type);
+    if (auto *sn = s->cast<SNodeOpStmt>())
+      h = mix(h, (std::uint64_t)sn->op_type);
     return h;
   }
 

--- a/quadrants/transforms/offload.cpp
+++ b/quadrants/transforms/offload.cpp
@@ -4,6 +4,7 @@
 #include "quadrants/ir/analysis.h"
 #include "quadrants/ir/visitors.h"
 #include "quadrants/program/program.h"
+#include "quadrants/transforms/offload_stable_key.h"
 
 #include <set>
 #include <unordered_map>
@@ -445,8 +446,8 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     QD_ASSERT(current_offloaded_);
   }
 
-  // Record the values written into each local (alloca) so assign_offsets() can fold an alloca's def/update chain
-  // into its ordering key. Allocas have no operands, so stable_key() alone keys them on statement kind + type only
+  // Record the values written into each local (alloca) so GlobalTmpOrdering can fold an alloca's def/update chain
+  // into its ordering key. Allocas have no operands, so a content key alone keys them on statement kind + type only
   // and two same-typed cross-offload locals share a key (PR #864 review r3797057477). Recorded during the same
   // traversal that collects cross-offload values; dest is squashed so element stores into local tensors are
   // attributed to their base alloca.
@@ -491,129 +492,12 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     }
   }
 
-  // FNV-1a string hash / mixing step, shared by local_key() and stable_key().
-  static std::uint64_t hstr(const std::string &str) {
-    std::uint64_t h = 1469598103934665603ULL;
-    for (unsigned char c : str)
-      h = (h ^ c) * 1099511628211ULL;
-    return h;
-  }
-  static std::uint64_t mix(std::uint64_t h, std::uint64_t x) {
-    return (h ^ x) * 1099511628211ULL;
-  }
-
-  // Offset-free content hash of a single statement, EXCLUDING its operands: statement kind, type, and
-  // constant/arg identity. Operand keys are folded in by stable_key(); factoring this out lets stable_key()
-  // walk the operand-def DAG iteratively.
-  std::uint64_t local_key(Stmt *s) {
-    std::uint64_t h = hstr(typeid(*s).name());
-    h = mix(h, hstr(s->ret_type.to_string()));
-    if (auto *c = s->cast<ConstStmt>())
-      h = mix(h, hstr(c->val.stringify()));
-    if (auto *a = s->cast<ArgLoadStmt>()) {
-      for (int id : a->arg_id)
-        h = mix(h, (std::uint64_t)(unsigned)id);
-      h = mix(h, (std::uint64_t)a->is_ptr);
-    }
-    // Semantic discriminant fields: statements of the same class, return type, and operands can still differ in
-    // an op_type (or cast target / bit-vectorization flag). Without these, e.g. a + b and a - b hash equal and
-    // stable_sort falls back to traversal order for them, reintroducing exactly the offset instability this
-    // content-keyed ordering exists to remove (PR #864 review r3776549281).
-    if (auto *u = s->cast<UnaryOpStmt>()) {
-      h = mix(h, (std::uint64_t)u->op_type);
-      if (u->is_cast())
-        h = mix(h, hstr(u->cast_type.to_string()));
-    }
-    if (auto *b = s->cast<BinaryOpStmt>()) {
-      h = mix(h, (std::uint64_t)b->op_type);
-      h = mix(h, (std::uint64_t)b->is_bit_vectorized);
-    }
-    if (auto *t = s->cast<TernaryOpStmt>())
-      h = mix(h, (std::uint64_t)t->op_type);
-    if (auto *a = s->cast<AtomicOpStmt>())
-      h = mix(h, (std::uint64_t)a->op_type);
-    if (auto *sn = s->cast<SNodeOpStmt>())
-      h = mix(h, (std::uint64_t)sn->op_type);
-    return h;
-  }
-
-  // Offset-free content hash over the value's operand-def DAG: a value's key depends on WHAT it is (local_key)
-  // plus the keys of its operands, not on offload traversal order. Memoized (also dedups shared subexpressions),
-  // and used to order global-temp slot assignment stably (S2a').
-  //
-  // Computed with an explicit worklist rather than recursion so that native stack depth does NOT grow with the
-  // length of the SSA dependency chain: a deeply unrolled / generated straight-line expression could otherwise
-  // overflow the compiler's stack here (PR #864 review r3796280238). Post-order: a statement is hashed only once
-  // all its operands are memoized. `on_stack_` breaks any back-edge defensively (the SSA def DAG is acyclic, so
-  // this never fires in practice); a back-edge operand contributes key 0.
-  std::uint64_t stable_key(Stmt *s) {
-    if (s == nullptr)
-      return 0;
-    if (auto it = key_memo_.find(s); it != key_memo_.end())
-      return it->second;
-    std::vector<Stmt *> stack{s};
-    while (!stack.empty()) {
-      Stmt *cur = stack.back();
-      if (key_memo_.count(cur)) {
-        stack.pop_back();
-        continue;
-      }
-      bool ready = true;
-      for (auto *op : cur->get_operands()) {
-        if (op != nullptr && !key_memo_.count(op) && !on_stack_.count(op)) {
-          stack.push_back(op);
-          ready = false;
-        }
-      }
-      if (ready) {
-        std::uint64_t h = local_key(cur);
-        for (auto *op : cur->get_operands())
-          h = mix(h, op != nullptr && key_memo_.count(op) ? key_memo_[op] : 0);
-        key_memo_[cur] = h;
-        on_stack_.erase(cur);
-        stack.pop_back();
-      } else {
-        on_stack_.insert(cur);
-      }
-    }
-    return key_memo_[s];
-  }
-
-  // The value written by a local store / atomic (the RHS of the update), or null for anything we don't model.
-  static Stmt *store_value(Stmt *store) {
-    if (auto *s = store->cast<LocalStoreStmt>())
-      return s->val;
-    if (auto *a = store->cast<AtomicOpStmt>())
-      return a->val;
-    return nullptr;
-  }
-
-  // Ordering key for global-temp slot assignment: stable_key(), plus -- for allocas only -- a content signature of
-  // the values written into the local. An alloca has no operands, so stable_key() keys it on statement kind + type
-  // alone; two same-typed cross-offload locals would then share a key and fall back to traversal order, retaining
-  // the offset instability this ordering removes (PR #864 review r3797057477). Fold in local_key(store) (which
-  // carries the store-vs-atomic kind and, for atomics, the op) and the content key of each stored value. Those
-  // stored values reference the alloca only through loads, and a load reaches the alloca via the operand DAG where
-  // the alloca is a childless leaf, so stable_key() stays acyclic and this signature is independent of evaluation
-  // order. Best-effort: two locals with identical types AND identical update chains still collide (harmless -- they
-  // are genuinely interchangeable), and store order (stable for a given local) is significant.
-  std::uint64_t sort_key(Stmt *s) {
-    std::uint64_t h = stable_key(s);
-    if (s->is<AllocaStmt>()) {
-      if (auto it = alloca_stores_.find(s); it != alloca_stores_.end())
-        for (auto *store : it->second)
-          h = mix(mix(h, local_key(store)), stable_key(store_value(store)));
-    }
-    return h;
-  }
-
   // Assign a global-temp offset to every collected cross-offload value, reusing allocate_global's sizing/alignment
-  // verbatim. Values are ordered by sort_key first (stable_sort keeps traversal order among equal keys), so a
-  // slot's offset is a function of its content rather than of traversal order -- which is what keeps a task's IR,
+  // verbatim. GlobalTmpOrdering first reorders the values into a content-keyed order (see offload_stable_key.h), so
+  // a slot's offset is a function of its content rather than of traversal order -- which is what keeps a task's IR,
   // and therefore its cache key, stable across edits elsewhere in the kernel.
   void assign_offsets() {
-    std::stable_sort(ordered_values_.begin(), ordered_values_.end(),
-                     [this](Stmt *a, Stmt *b) { return sort_key(a) < sort_key(b); });
+    GlobalTmpOrdering().sort(ordered_values_, alloca_stores_);
     for (auto *v : ordered_values_)
       local_to_global_[v] = allocate_global(v->ret_type);
   }
@@ -655,12 +539,9 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   // Cross-offload values in first-encounter (traversal) order, offset assignment deferred to assign_offsets().
   std::vector<Stmt *> ordered_values_;
   std::unordered_set<Stmt *> value_seen_;
-  std::unordered_map<Stmt *, std::uint64_t> key_memo_;
-  // Statements currently on stable_key()'s worklist, used to defensively break back-edges.
-  std::unordered_set<Stmt *> on_stack_;
   // Per-alloca list of the local-store / atomic statements that write into it, in traversal order. Consumed by
-  // sort_key() to give same-typed cross-offload locals distinct content-derived ordering keys.
-  std::unordered_map<Stmt *, std::vector<Stmt *>> alloca_stores_;
+  // GlobalTmpOrdering to give same-typed cross-offload locals distinct content-derived ordering keys.
+  GlobalTmpOrdering::AllocaStores alloca_stores_;
 };
 
 // Store intermediate values to globals so that statements in later offloaded

--- a/quadrants/transforms/offload.cpp
+++ b/quadrants/transforms/offload.cpp
@@ -445,6 +445,29 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     QD_ASSERT(current_offloaded_);
   }
 
+  // Record the values written into each local (alloca) so assign_offsets() can fold an alloca's def/update chain
+  // into its ordering key. Allocas have no operands, so stable_key() alone keys them on statement kind + type only
+  // and two same-typed cross-offload locals share a key (PR #864 review r3797057477). Recorded during the same
+  // traversal that collects cross-offload values; dest is squashed so element stores into local tensors are
+  // attributed to their base alloca.
+  void record_local_store(Stmt *dest, Stmt *store) {
+    if (dest == nullptr)
+      return;
+    Stmt *base = SquashPtrOffset::run(dest);
+    if (base != nullptr && base->is<AllocaStmt>())
+      alloca_stores_[base].push_back(store);
+  }
+
+  void visit(LocalStoreStmt *stmt) override {
+    record_local_store(stmt->dest, stmt);
+    generic_visit(stmt);
+  }
+
+  void visit(AtomicOpStmt *stmt) override {
+    record_local_store(stmt->dest, stmt);
+    generic_visit(stmt);
+  }
+
   void test_and_allocate(Stmt *stmt) {
     if (stmt == nullptr)
       return;
@@ -556,13 +579,41 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     return key_memo_[s];
   }
 
+  // The value written by a local store / atomic (the RHS of the update), or null for anything we don't model.
+  static Stmt *store_value(Stmt *store) {
+    if (auto *s = store->cast<LocalStoreStmt>())
+      return s->val;
+    if (auto *a = store->cast<AtomicOpStmt>())
+      return a->val;
+    return nullptr;
+  }
+
+  // Ordering key for global-temp slot assignment: stable_key(), plus -- for allocas only -- a content signature of
+  // the values written into the local. An alloca has no operands, so stable_key() keys it on statement kind + type
+  // alone; two same-typed cross-offload locals would then share a key and fall back to traversal order, retaining
+  // the offset instability this ordering removes (PR #864 review r3797057477). Fold in local_key(store) (which
+  // carries the store-vs-atomic kind and, for atomics, the op) and the content key of each stored value. Those
+  // stored values reference the alloca only through loads, and a load reaches the alloca via the operand DAG where
+  // the alloca is a childless leaf, so stable_key() stays acyclic and this signature is independent of evaluation
+  // order. Best-effort: two locals with identical types AND identical update chains still collide (harmless -- they
+  // are genuinely interchangeable), and store order (stable for a given local) is significant.
+  std::uint64_t sort_key(Stmt *s) {
+    std::uint64_t h = stable_key(s);
+    if (s->is<AllocaStmt>()) {
+      if (auto it = alloca_stores_.find(s); it != alloca_stores_.end())
+        for (auto *store : it->second)
+          h = mix(mix(h, local_key(store)), stable_key(store_value(store)));
+    }
+    return h;
+  }
+
   // Assign a global-temp offset to every collected cross-offload value, reusing allocate_global's sizing/alignment
-  // verbatim. Values are ordered by stable_key first (stable_sort keeps traversal order among equal keys), so a
+  // verbatim. Values are ordered by sort_key first (stable_sort keeps traversal order among equal keys), so a
   // slot's offset is a function of its content rather than of traversal order -- which is what keeps a task's IR,
   // and therefore its cache key, stable across edits elsewhere in the kernel.
   void assign_offsets() {
     std::stable_sort(ordered_values_.begin(), ordered_values_.end(),
-                     [this](Stmt *a, Stmt *b) { return stable_key(a) < stable_key(b); });
+                     [this](Stmt *a, Stmt *b) { return sort_key(a) < sort_key(b); });
     for (auto *v : ordered_values_)
       local_to_global_[v] = allocate_global(v->ret_type);
   }
@@ -607,6 +658,9 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   std::unordered_map<Stmt *, std::uint64_t> key_memo_;
   // Statements currently on stable_key()'s worklist, used to defensively break back-edges.
   std::unordered_set<Stmt *> on_stack_;
+  // Per-alloca list of the local-store / atomic statements that write into it, in traversal order. Consumed by
+  // sort_key() to give same-typed cross-offload locals distinct content-derived ordering keys.
+  std::unordered_map<Stmt *, std::vector<Stmt *>> alloca_stores_;
 };
 
 // Store intermediate values to globals so that statements in later offloaded

--- a/quadrants/transforms/offload.cpp
+++ b/quadrants/transforms/offload.cpp
@@ -468,23 +468,21 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
     }
   }
 
-  // Recursive, offset-free content hash over the value's operand-def DAG: a value's key depends on WHAT it is
-  // (statement kind, type, constant/arg identity, operand structure), not on offload traversal order. Memoized (also
-  // dedups shared subexpressions). Used to order global-temp slot assignment stably (S2a').
-  std::uint64_t stable_key(Stmt *s) {
-    if (s == nullptr)
-      return 0;
-    auto it = key_memo_.find(s);
-    if (it != key_memo_.end())
-      return it->second;
-    key_memo_[s] = 1;  // cycle guard; SSA def DAG is acyclic so this is only defensive
-    auto hstr = [](const std::string &str) {
-      std::uint64_t h = 1469598103934665603ULL;
-      for (unsigned char c : str)
-        h = (h ^ c) * 1099511628211ULL;
-      return h;
-    };
-    auto mix = [](std::uint64_t h, std::uint64_t x) { return (h ^ x) * 1099511628211ULL; };
+  // FNV-1a string hash / mixing step, shared by local_key() and stable_key().
+  static std::uint64_t hstr(const std::string &str) {
+    std::uint64_t h = 1469598103934665603ULL;
+    for (unsigned char c : str)
+      h = (h ^ c) * 1099511628211ULL;
+    return h;
+  }
+  static std::uint64_t mix(std::uint64_t h, std::uint64_t x) {
+    return (h ^ x) * 1099511628211ULL;
+  }
+
+  // Offset-free content hash of a single statement, EXCLUDING its operands: statement kind, type, and
+  // constant/arg identity. Operand keys are folded in by stable_key(); factoring this out lets stable_key()
+  // walk the operand-def DAG iteratively.
+  std::uint64_t local_key(Stmt *s) {
     std::uint64_t h = hstr(typeid(*s).name());
     h = mix(h, hstr(s->ret_type.to_string()));
     if (auto *c = s->cast<ConstStmt>())
@@ -494,10 +492,49 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
         h = mix(h, (std::uint64_t)(unsigned)id);
       h = mix(h, (std::uint64_t)a->is_ptr);
     }
-    for (auto *op : s->get_operands())
-      h = mix(h, stable_key(op));
-    key_memo_[s] = h;
     return h;
+  }
+
+  // Offset-free content hash over the value's operand-def DAG: a value's key depends on WHAT it is (local_key)
+  // plus the keys of its operands, not on offload traversal order. Memoized (also dedups shared subexpressions),
+  // and used to order global-temp slot assignment stably (S2a').
+  //
+  // Computed with an explicit worklist rather than recursion so that native stack depth does NOT grow with the
+  // length of the SSA dependency chain: a deeply unrolled / generated straight-line expression could otherwise
+  // overflow the compiler's stack here (PR #864 review r3796280238). Post-order: a statement is hashed only once
+  // all its operands are memoized. `on_stack_` breaks any back-edge defensively (the SSA def DAG is acyclic, so
+  // this never fires in practice); a back-edge operand contributes key 0.
+  std::uint64_t stable_key(Stmt *s) {
+    if (s == nullptr)
+      return 0;
+    if (auto it = key_memo_.find(s); it != key_memo_.end())
+      return it->second;
+    std::vector<Stmt *> stack{s};
+    while (!stack.empty()) {
+      Stmt *cur = stack.back();
+      if (key_memo_.count(cur)) {
+        stack.pop_back();
+        continue;
+      }
+      bool ready = true;
+      for (auto *op : cur->get_operands()) {
+        if (op != nullptr && !key_memo_.count(op) && !on_stack_.count(op)) {
+          stack.push_back(op);
+          ready = false;
+        }
+      }
+      if (ready) {
+        std::uint64_t h = local_key(cur);
+        for (auto *op : cur->get_operands())
+          h = mix(h, op != nullptr && key_memo_.count(op) ? key_memo_[op] : 0);
+        key_memo_[cur] = h;
+        on_stack_.erase(cur);
+        stack.pop_back();
+      } else {
+        on_stack_.insert(cur);
+      }
+    }
+    return key_memo_[s];
   }
 
   // Assign a global-temp offset to every collected cross-offload value, reusing allocate_global's sizing/alignment
@@ -549,6 +586,8 @@ class IdentifyValuesUsedInOtherOffloads : public BasicStmtVisitor {
   std::vector<Stmt *> ordered_values_;
   std::unordered_set<Stmt *> value_seen_;
   std::unordered_map<Stmt *, std::uint64_t> key_memo_;
+  // Statements currently on stable_key()'s worklist, used to defensively break back-edges.
+  std::unordered_set<Stmt *> on_stack_;
 };
 
 // Store intermediate values to globals so that statements in later offloaded

--- a/quadrants/transforms/offload_stable_key.h
+++ b/quadrants/transforms/offload_stable_key.h
@@ -1,0 +1,164 @@
+#pragma once
+
+#include "quadrants/ir/ir.h"
+#include "quadrants/ir/statements.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+#include <typeinfo>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace quadrants::lang {
+namespace irpass {
+
+// Content-keyed ordering for cross-offload global-temp slot assignment.
+//
+// A cross-offload value's global-temp offset is part of the IR of every task that reads or writes it, so if the
+// offset moved whenever an unrelated edit reordered offload traversal, those otherwise-unchanged tasks would
+// re-key and miss the per-task compile cache. GlobalTmpOrdering removes that coupling: given the collected
+// cross-offload values (in first-encounter / traversal order) and, per alloca, the local-store / atomic
+// statements that write into it, sort() reorders the values so a value's position is a function of WHAT it is
+// (its operand-def DAG content) rather than of traversal order.
+//
+// Ownership split: the caller (IdentifyValuesUsedInOtherOffloads) collects the values and the alloca-store map
+// during its normal traversal and does the actual offset allocation; this helper only computes the stable order.
+class GlobalTmpOrdering {
+ public:
+  // Per-alloca list of the local-store / atomic statements that write into it, in traversal order.
+  using AllocaStores = std::unordered_map<Stmt *, std::vector<Stmt *>>;
+
+  // Stable-sort `values` in place by content key. stable_sort keeps traversal order among equal keys, so a slot's
+  // offset is a function of its content rather than of traversal order.
+  void sort(std::vector<Stmt *> &values, const AllocaStores &alloca_stores) {
+    std::stable_sort(values.begin(), values.end(), [this, &alloca_stores](Stmt *a, Stmt *b) {
+      return sort_key(a, alloca_stores) < sort_key(b, alloca_stores);
+    });
+  }
+
+ private:
+  // FNV-1a string hash / mixing step, shared by local_key() and stable_key().
+  static std::uint64_t hstr(const std::string &str) {
+    std::uint64_t h = 1469598103934665603ULL;
+    for (unsigned char c : str)
+      h = (h ^ c) * 1099511628211ULL;
+    return h;
+  }
+  static std::uint64_t mix(std::uint64_t h, std::uint64_t x) {
+    return (h ^ x) * 1099511628211ULL;
+  }
+
+  // Offset-free content hash of a single statement, EXCLUDING its operands: statement kind, type, and
+  // constant/arg identity. Operand keys are folded in by stable_key(); factoring this out lets stable_key()
+  // walk the operand-def DAG iteratively.
+  std::uint64_t local_key(Stmt *s) {
+    std::uint64_t h = hstr(typeid(*s).name());
+    h = mix(h, hstr(s->ret_type.to_string()));
+    if (auto *c = s->cast<ConstStmt>())
+      h = mix(h, hstr(c->val.stringify()));
+    if (auto *a = s->cast<ArgLoadStmt>()) {
+      for (int id : a->arg_id)
+        h = mix(h, (std::uint64_t)(unsigned)id);
+      h = mix(h, (std::uint64_t)a->is_ptr);
+    }
+    // Semantic discriminant fields: statements of the same class, return type, and operands can still differ in
+    // an op_type (or cast target / bit-vectorization flag). Without these, e.g. a + b and a - b hash equal and
+    // stable_sort falls back to traversal order for them, reintroducing exactly the offset instability this
+    // content-keyed ordering exists to remove (PR #864 review r3776549281).
+    if (auto *u = s->cast<UnaryOpStmt>()) {
+      h = mix(h, (std::uint64_t)u->op_type);
+      if (u->is_cast())
+        h = mix(h, hstr(u->cast_type.to_string()));
+    }
+    if (auto *b = s->cast<BinaryOpStmt>()) {
+      h = mix(h, (std::uint64_t)b->op_type);
+      h = mix(h, (std::uint64_t)b->is_bit_vectorized);
+    }
+    if (auto *t = s->cast<TernaryOpStmt>())
+      h = mix(h, (std::uint64_t)t->op_type);
+    if (auto *a = s->cast<AtomicOpStmt>())
+      h = mix(h, (std::uint64_t)a->op_type);
+    if (auto *sn = s->cast<SNodeOpStmt>())
+      h = mix(h, (std::uint64_t)sn->op_type);
+    return h;
+  }
+
+  // Offset-free content hash over the value's operand-def DAG: a value's key depends on WHAT it is (local_key)
+  // plus the keys of its operands, not on offload traversal order. Memoized (also dedups shared subexpressions),
+  // and used to order global-temp slot assignment stably (S2a').
+  //
+  // Computed with an explicit worklist rather than recursion so that native stack depth does NOT grow with the
+  // length of the SSA dependency chain: a deeply unrolled / generated straight-line expression could otherwise
+  // overflow the compiler's stack here (PR #864 review r3796280238). Post-order: a statement is hashed only once
+  // all its operands are memoized. `on_stack_` breaks any back-edge defensively (the SSA def DAG is acyclic, so
+  // this never fires in practice); a back-edge operand contributes key 0.
+  std::uint64_t stable_key(Stmt *s) {
+    if (s == nullptr)
+      return 0;
+    if (auto it = key_memo_.find(s); it != key_memo_.end())
+      return it->second;
+    std::vector<Stmt *> stack{s};
+    while (!stack.empty()) {
+      Stmt *cur = stack.back();
+      if (key_memo_.count(cur)) {
+        stack.pop_back();
+        continue;
+      }
+      bool ready = true;
+      for (auto *op : cur->get_operands()) {
+        if (op != nullptr && !key_memo_.count(op) && !on_stack_.count(op)) {
+          stack.push_back(op);
+          ready = false;
+        }
+      }
+      if (ready) {
+        std::uint64_t h = local_key(cur);
+        for (auto *op : cur->get_operands())
+          h = mix(h, op != nullptr && key_memo_.count(op) ? key_memo_[op] : 0);
+        key_memo_[cur] = h;
+        on_stack_.erase(cur);
+        stack.pop_back();
+      } else {
+        on_stack_.insert(cur);
+      }
+    }
+    return key_memo_[s];
+  }
+
+  // The value written by a local store / atomic (the RHS of the update), or null for anything we don't model.
+  static Stmt *store_value(Stmt *store) {
+    if (auto *s = store->cast<LocalStoreStmt>())
+      return s->val;
+    if (auto *a = store->cast<AtomicOpStmt>())
+      return a->val;
+    return nullptr;
+  }
+
+  // Ordering key for global-temp slot assignment: stable_key(), plus -- for allocas only -- a content signature of
+  // the values written into the local. An alloca has no operands, so stable_key() keys it on statement kind + type
+  // alone; two same-typed cross-offload locals would then share a key and fall back to traversal order, retaining
+  // the offset instability this ordering removes (PR #864 review r3797057477). Fold in local_key(store) (which
+  // carries the store-vs-atomic kind and, for atomics, the op) and the content key of each stored value. Those
+  // stored values reference the alloca only through loads, and a load reaches the alloca via the operand DAG where
+  // the alloca is a childless leaf, so stable_key() stays acyclic and this signature is independent of evaluation
+  // order. Best-effort: two locals with identical types AND identical update chains still collide (harmless -- they
+  // are genuinely interchangeable), and store order (stable for a given local) is significant.
+  std::uint64_t sort_key(Stmt *s, const AllocaStores &alloca_stores) {
+    std::uint64_t h = stable_key(s);
+    if (s->is<AllocaStmt>()) {
+      if (auto it = alloca_stores.find(s); it != alloca_stores.end())
+        for (auto *store : it->second)
+          h = mix(mix(h, local_key(store)), stable_key(store_value(store)));
+    }
+    return h;
+  }
+
+  std::unordered_map<Stmt *, std::uint64_t> key_memo_;
+  // Statements currently on stable_key()'s worklist, used to defensively break back-edges.
+  std::unordered_set<Stmt *> on_stack_;
+};
+
+}  // namespace irpass
+}  // namespace quadrants::lang

--- a/tests/python/test_stable_gtmp_offsets.py
+++ b/tests/python/test_stable_gtmp_offsets.py
@@ -89,10 +89,13 @@ def test_stable_gtmp_offsets_are_content_keyed(tmp_path: pathlib.Path, monkeypat
     reason="Known limitation flagged in PR #864 review (r3776617702): global-temp slots are bump-allocated in "
     "stable_key order, so a slot's offset is the cumulative size of every lower-keyed value rather than a function "
     "of the value alone. Inserting an unrelated cross-offload value whose key sorts earlier therefore still shifts "
-    "an unchanged value's offset (here i64: 0 -> 8), re-keying tasks that were not edited. This costs some per-task "
-    "cache reuse but never correctness (within a build all tasks agree on the layout). Remove this xfail when "
-    "offsets are made fully content-addressed.",
-    strict=True,
+    "an unchanged value's offset, re-keying tasks that were not edited. This costs some per-task cache reuse but "
+    "never correctness (within a build all tasks agree on the layout). Remove this xfail when offsets are made "
+    "fully content-addressed. Non-strict: stable_key incorporates typeid(*s).name(), whose ordering is "
+    "implementation-defined, so whether the inserted i32 sorts before the i64 (and thus whether this property "
+    "happens to hold on a given toolchain) is not portable -- a strict xfail would flip to a suite failure as an "
+    "XPASS on a toolchain that orders them the other way, even though the limitation still exists.",
+    strict=False,
 )
 @test_utils.test(arch=[qd.cpu], offline_cache=False)
 def test_gtmp_offset_stable_under_unrelated_insertion(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
@@ -100,8 +103,12 @@ def test_gtmp_offset_stable_under_unrelated_insertion(tmp_path: pathlib.Path, mo
 
     Adding an *unrelated* cross-offload value elsewhere in the kernel should not move an existing
     value's offset (otherwise the untouched value's task re-keys and misses the per-task cache).
-    Today it does move: the inserted i32 value sorts before the i64 value by stable_key, and the
-    dense bump allocator pushes the i64 slot from offset 0 to offset 8.
+    Today it can still move: when the inserted i32 value sorts before the i64 value by stable_key,
+    the dense bump allocator pushes the i64 slot to a higher offset. Whether that ordering happens
+    is toolchain-dependent (stable_key uses typeid(*s).name()), so this is a non-strict xfail: on
+    toolchains where the i32 sorts after the i64 the offset is unchanged and the test XPASSes, which
+    is fine -- the limitation is that the offset is *not guaranteed* to be stable, not that it always
+    moves.
     """
     monkeypatch.setenv("QD_DUMP_IR", "1")
     qd.lang.impl.current_cfg().debug_dump_path = str(tmp_path)
@@ -140,5 +147,6 @@ def test_gtmp_offset_stable_under_unrelated_insertion(tmp_path: pathlib.Path, mo
     assert "i64" in off_only and "i64" in off_both, (off_only, off_both)
     assert "i32" in off_both, off_both
     # The desired (not-yet-achieved) property: the i64 value's offset is unaffected by the unrelated
-    # i32 value. This currently fails (0 vs 8), which is why the test is marked xfail.
+    # i32 value. This is not guaranteed today (the i32 may sort before the i64 and bump its offset),
+    # which is why the test is a non-strict xfail rather than a hard assertion.
     assert off_only["i64"] == off_both["i64"], (off_only, off_both)

--- a/tests/python/test_stable_gtmp_offsets.py
+++ b/tests/python/test_stable_gtmp_offsets.py
@@ -12,6 +12,11 @@ _GTMP_RE = re.compile(r"<\*(\w+)> .* = global tmp var \(offset = (\d+) B\)")
 _OFFSET_RE = re.compile(r"global tmp var \(offset = (\d+) B\)")
 _CONST_RE = re.compile(r"= const (\d+)")
 _OFFLOAD_RE = re.compile(r"\$\d+ = offloaded")
+# A promoted intermediate is a binary op whose result is stored into a fresh global temp:
+#   $35 = add $32 $34   /   $36 = global tmp var (offset = 8 B)   /   $37 : global store [$36 <- $35]
+_GTMP_DEF_RE = re.compile(r"\$(\d+) = global tmp var \(offset = (\d+) B\)")
+_BINOP_RE = re.compile(r"\$(\d+) = (add|sub|mul|div|mod|bit_and|bit_or|bit_xor|min|max) ")
+_GSTORE_RE = re.compile(r"global store \[\$(\d+) <- \$(\d+)\]")
 
 
 def _gtmp_offsets_by_type(dump_dir: pathlib.Path, kernel_name: str):
@@ -65,6 +70,36 @@ def _gtmp_offset_by_producer_const(dump_dir: pathlib.Path, kernel_name: str, mar
                 cur_offsets.add(int(om.group(1)))
         flush()
     return mapping
+
+
+def _promoted_binop_offset_by_op(dump_dir: pathlib.Path, kernel_name: str):
+    """Map a binary op kind (e.g. "add") to the global-temp offset its promoted result is stored into.
+
+    A cross-offload SSA intermediate (not a local) is promoted by writing the op's result straight into a global
+    temp via a ``global store``. Following that store's stored value back to the defining op lets us pin a
+    *specific op* to its slot offset, so we can tell whether two same-operand ops (add vs sub) keep their slots
+    when their source order swaps. Ops whose result feeds an atomic accumulation or an external-pointer store
+    (rather than a global-temp store) are ignored.
+    """
+    files = sorted(dump_dir.glob(f"*{kernel_name}*after_offload*"))
+    assert files, f"no after_offload IR dump for {kernel_name} in {dump_dir}"
+    result: dict[str, int] = {}
+    for f in files:
+        gtmp_offset: dict[str, int] = {}
+        op_of: dict[str, str] = {}
+        for line in f.read_text().splitlines():
+            dm = _GTMP_DEF_RE.search(line)
+            if dm:
+                gtmp_offset[dm.group(1)] = int(dm.group(2))
+            bm = _BINOP_RE.search(line)
+            if bm:
+                op_of[bm.group(1)] = bm.group(2)
+            sm = _GSTORE_RE.search(line)
+            if sm:
+                dest, val = sm.group(1), sm.group(2)
+                if val in op_of and dest in gtmp_offset:
+                    result[op_of[val]] = gtmp_offset[dest]
+    return result
 
 
 @test_utils.test(arch=[qd.cpu], offline_cache=False)
@@ -191,6 +226,72 @@ def test_stable_gtmp_offsets_same_typed_locals_are_content_keyed(
     # The value->offset mapping is invariant to the source order of the two same-typed producers -- which only
     # holds because the ordering key incorporates each local's def/update chain.
     assert map_ac == map_ca, (map_ac, map_ca)
+
+
+@test_utils.test(arch=[qd.cpu], offline_cache=False)
+def test_stable_gtmp_offsets_distinguish_op_type(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Cross-offload intermediates that differ only in their op get distinct, traversal-order-stable slots.
+
+    p = x + y and q = x - y share operands and return type, so unless the content key includes the op these two
+    promoted intermediates hash equal. Cross-offload values are collected in traversal (consumer-use) order and
+    then stable_sort'd by their key, so for colliding keys the slot follows traversal order: an unrelated edit
+    that reorders the consumer (p + q vs q + p) then swaps the two producer-side global-temp offsets and re-keys a
+    producer task that itself did not change (PR #864 review r3776549281). Mixing op_type into the key pins each
+    op to its slot regardless of consumer order. Here p and q are plain SSA values (not locals), so this exercises
+    the op_type contribution directly rather than the alloca def-chain signature.
+    """
+    monkeypatch.setenv("QD_DUMP_IR", "1")
+    qd.lang.impl.current_cfg().debug_dump_path = str(tmp_path)
+
+    n = 64
+
+    @qd.kernel
+    def op_pq(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        x = 0  # two shared operands, tagged so they stay distinct cross-offload values
+        for i in range(3):
+            x += i + 700
+        y = 0
+        for i in range(5):
+            y += i + 900
+        p = x + y  # add intermediate
+        q = x - y  # sub intermediate
+        for i in range(n):
+            out[i] = p + q + i  # consumer references the add intermediate first
+
+    @qd.kernel
+    def op_qp(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        x = 0  # identical producer: p and q are defined in the same order...
+        for i in range(3):
+            x += i + 700
+        y = 0
+        for i in range(5):
+            y += i + 900
+        p = x + y
+        q = x - y
+        for i in range(n):
+            out[i] = q + p + i  # ...only the (unrelated) consumer use order is swapped
+
+    out = qd.ndarray(qd.i32, shape=(n,))
+    op_pq(out)
+    qd.sync()
+    res_pq = out.to_numpy().copy()
+
+    op_qp(out)
+    qd.sync()
+    res_qp = out.to_numpy().copy()
+
+    # Both consumer orderings compute the same result.
+    assert (res_pq == res_qp).all()
+
+    map_pq = _promoted_binop_offset_by_op(tmp_path, "op_pq")
+    map_qp = _promoted_binop_offset_by_op(tmp_path, "op_qp")
+
+    # Both the add and the sub intermediate were promoted, to disjoint slots.
+    assert set(map_pq) == {"add", "sub"}, map_pq
+    assert map_pq["add"] != map_pq["sub"], map_pq
+    # Each op keeps its producer-side slot even though the consumer traversal order changed -- only true because
+    # op_type is part of the ordering key. Without it the add/sub slots swap with the consumer order.
+    assert map_pq == map_qp, (map_pq, map_qp)
 
 
 @pytest.mark.xfail(

--- a/tests/python/test_stable_gtmp_offsets.py
+++ b/tests/python/test_stable_gtmp_offsets.py
@@ -9,6 +9,9 @@ from tests import test_utils
 
 # GlobalTemporaryStmt prints as e.g. "<*i64> $7 = global tmp var (offset = 8 B)".
 _GTMP_RE = re.compile(r"<\*(\w+)> .* = global tmp var \(offset = (\d+) B\)")
+_OFFSET_RE = re.compile(r"global tmp var \(offset = (\d+) B\)")
+_CONST_RE = re.compile(r"= const (\d+)")
+_OFFLOAD_RE = re.compile(r"\$\d+ = offloaded")
 
 
 def _gtmp_offsets_by_type(dump_dir: pathlib.Path, kernel_name: str):
@@ -21,6 +24,47 @@ def _gtmp_offsets_by_type(dump_dir: pathlib.Path, kernel_name: str):
             if m:
                 per_type.setdefault(m.group(1), set()).add(int(m.group(2)))
     return per_type
+
+
+def _gtmp_offset_by_producer_const(dump_dir: pathlib.Path, kernel_name: str, marker_consts: set[int]):
+    """Map a marker constant to the global-temp offset of the ``range_for`` task that produces it.
+
+    A cross-offload local is finalized inside a ``range_for`` producer task that both materializes a marker
+    constant (e.g. 101) and writes the accumulated value into a single ``global tmp var (offset = N B)``. That
+    lets us associate a *specific value* with its slot offset -- unlike ``_gtmp_offsets_by_type``, which only sees
+    the type -- so we can tell whether two *same-typed* locals kept their slots when their source order swaps.
+    Serial/init tasks (which hoist several constants and touch several temps) are ignored; only single-const,
+    single-temp ``range_for`` producers are mapped.
+    """
+    files = sorted(dump_dir.glob(f"*{kernel_name}*after_offload*"))
+    assert files, f"no after_offload IR dump for {kernel_name} in {dump_dir}"
+    mapping: dict[int, int] = {}
+    for f in files:
+        cur_consts: set[int] = set()
+        cur_offsets: set[int] = set()
+        in_range_for = False
+
+        def flush():
+            if in_range_for and len(cur_consts) == 1 and len(cur_offsets) == 1:
+                mapping[next(iter(cur_consts))] = next(iter(cur_offsets))
+
+        for line in f.read_text().splitlines():
+            if _OFFLOAD_RE.search(line):
+                flush()
+                cur_consts = set()
+                cur_offsets = set()
+                in_range_for = "range_for" in line
+                continue
+            if not in_range_for:
+                continue
+            cm = _CONST_RE.search(line)
+            if cm and int(cm.group(1)) in marker_consts:
+                cur_consts.add(int(cm.group(1)))
+            om = _OFFSET_RE.search(line)
+            if om:
+                cur_offsets.add(int(om.group(1)))
+        flush()
+    return mapping
 
 
 @test_utils.test(arch=[qd.cpu], offline_cache=False)
@@ -83,6 +127,70 @@ def test_stable_gtmp_offsets_are_content_keyed(tmp_path: pathlib.Path, monkeypat
     assert off_ab["i32"].isdisjoint(off_ab["i64"]), off_ab
     # The value->offset mapping is invariant to the source/traversal order of the producing offloads.
     assert off_ab == off_ba, (off_ab, off_ba)
+
+
+@test_utils.test(arch=[qd.cpu], offline_cache=False)
+def test_stable_gtmp_offsets_same_typed_locals_are_content_keyed(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Two *same-typed* cross-offload locals are ordered by their def/update chain, not by source order.
+
+    This is the case that statement class + return type cannot distinguish: an alloca has no operands, so both
+    locals key identically on kind + type and stable_sort would fall back to traversal order, swapping their
+    slots when the producing loops swap (PR #864 review r3797057477). sort_key() folds a content signature of the
+    values written into each local, so here the local built from constant 101 and the one built from 202 keep
+    their offsets regardless of which loop comes first. Each local is tagged with a distinct marker constant so
+    its slot can be identified in the dump.
+    """
+    monkeypatch.setenv("QD_DUMP_IR", "1")
+    qd.lang.impl.current_cfg().debug_dump_path = str(tmp_path)
+
+    n = 64
+    markers = {101, 202}
+
+    @qd.kernel
+    def local_ac(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        a = 0  # i32 local built from marker 101, produced first
+        for i in range(3):
+            a += i + 101
+        c = 0  # i32 local built from marker 202, produced second
+        for i in range(4):
+            c += i + 202
+        for i in range(n):
+            out[i] = a + c + i
+
+    @qd.kernel
+    def local_ca(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        c = 0  # same two locals, the 202 one produced first
+        for i in range(4):
+            c += i + 202
+        a = 0
+        for i in range(3):
+            a += i + 101
+        for i in range(n):
+            out[i] = a + c + i
+
+    out = qd.ndarray(qd.i32, shape=(n,))
+    local_ac(out)
+    qd.sync()
+    res_ac = out.to_numpy().copy()
+
+    local_ca(out)
+    qd.sync()
+    res_ca = out.to_numpy().copy()
+
+    # Both orderings compute the same result.
+    assert (res_ac == res_ca).all()
+
+    map_ac = _gtmp_offset_by_producer_const(tmp_path, "local_ac", markers)
+    map_ca = _gtmp_offset_by_producer_const(tmp_path, "local_ca", markers)
+
+    # Both same-typed locals were identified via their marker constants and occupy disjoint slots.
+    assert set(map_ac) == markers, map_ac
+    assert len(set(map_ac.values())) == 2, map_ac
+    # The value->offset mapping is invariant to the source order of the two same-typed producers -- which only
+    # holds because the ordering key incorporates each local's def/update chain.
+    assert map_ac == map_ca, (map_ac, map_ca)
 
 
 @pytest.mark.xfail(

--- a/tests/python/test_stable_gtmp_offsets.py
+++ b/tests/python/test_stable_gtmp_offsets.py
@@ -1,0 +1,144 @@
+import pathlib
+import re
+
+import pytest
+
+import quadrants as qd
+
+from tests import test_utils
+
+# GlobalTemporaryStmt prints as e.g. "<*i64> $7 = global tmp var (offset = 8 B)".
+_GTMP_RE = re.compile(r"<\*(\w+)> .* = global tmp var \(offset = (\d+) B\)")
+
+
+def _gtmp_offsets_by_type(dump_dir: pathlib.Path, kernel_name: str):
+    files = sorted(dump_dir.glob(f"*{kernel_name}*after_offload*"))
+    assert files, f"no after_offload IR dump for {kernel_name} in {dump_dir}"
+    per_type: dict[str, set[int]] = {}
+    for f in files:
+        for line in f.read_text().splitlines():
+            m = _GTMP_RE.search(line)
+            if m:
+                per_type.setdefault(m.group(1), set()).add(int(m.group(2)))
+    return per_type
+
+
+@test_utils.test(arch=[qd.cpu], offline_cache=False)
+def test_stable_gtmp_offsets_are_content_keyed(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """Cross-offload global-temp slots are assigned in a content-keyed order.
+
+    A value's global-temp offset depends on WHAT it is (statement kind, type, constant/arg identity,
+    operand structure), not on the order in which offloads happen to be traversed. Two kernels that
+    produce the same set of cross-offload values in a different source order must therefore get the
+    same value->offset mapping. With the previous traversal-order allocation, swapping the two
+    producing loops swapped the slots (i32@0/i64@8 vs i64@0/i32@8), which perturbed the IR -- and
+    hence the per-task cache key -- of tasks that were not edited.
+    """
+    monkeypatch.setenv("QD_DUMP_IR", "1")
+    qd.lang.impl.current_cfg().debug_dump_path = str(tmp_path)
+
+    n = 64
+
+    @qd.kernel
+    def order_ab(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        a = 0  # i32 cross-offload value, produced first
+        for i in range(3):
+            a += i
+        b = qd.cast(0, qd.i64)  # i64 cross-offload value, produced second
+        for i in range(5):
+            b += qd.cast(i * i, qd.i64)
+        for i in range(n):
+            out[i] = a + qd.cast(b, qd.i32) + i
+
+    @qd.kernel
+    def order_ba(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        b = qd.cast(0, qd.i64)  # same two values, i64 produced first
+        for i in range(5):
+            b += qd.cast(i * i, qd.i64)
+        a = 0
+        for i in range(3):
+            a += i
+        for i in range(n):
+            out[i] = a + qd.cast(b, qd.i32) + i
+
+    out = qd.ndarray(qd.i32, shape=(n,))
+    order_ab(out)
+    qd.sync()
+    res_ab = out.to_numpy().copy()
+
+    order_ba(out)
+    qd.sync()
+    res_ba = out.to_numpy().copy()
+
+    # Both orderings compute the same result.
+    assert (res_ab == res_ba).all()
+
+    off_ab = _gtmp_offsets_by_type(tmp_path, "order_ab")
+    off_ba = _gtmp_offsets_by_type(tmp_path, "order_ba")
+
+    # Both a cross-offload i32 slot and a cross-offload i64 slot are present.
+    assert "i32" in off_ab and "i64" in off_ab, off_ab
+    # Each value gets exactly one slot, and the two values occupy disjoint (non-overlapping) slots.
+    assert len(off_ab["i32"]) == 1 and len(off_ab["i64"]) == 1, off_ab
+    assert off_ab["i32"].isdisjoint(off_ab["i64"]), off_ab
+    # The value->offset mapping is invariant to the source/traversal order of the producing offloads.
+    assert off_ab == off_ba, (off_ab, off_ba)
+
+
+@pytest.mark.xfail(
+    reason="Known limitation flagged in PR #864 review (r3776617702): global-temp slots are bump-allocated in "
+    "stable_key order, so a slot's offset is the cumulative size of every lower-keyed value rather than a function "
+    "of the value alone. Inserting an unrelated cross-offload value whose key sorts earlier therefore still shifts "
+    "an unchanged value's offset (here i64: 0 -> 8), re-keying tasks that were not edited. This costs some per-task "
+    "cache reuse but never correctness (within a build all tasks agree on the layout). Remove this xfail when "
+    "offsets are made fully content-addressed.",
+    strict=True,
+)
+@test_utils.test(arch=[qd.cpu], offline_cache=False)
+def test_gtmp_offset_stable_under_unrelated_insertion(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    """A cross-offload value's global-temp slot should depend only on the value itself.
+
+    Adding an *unrelated* cross-offload value elsewhere in the kernel should not move an existing
+    value's offset (otherwise the untouched value's task re-keys and misses the per-task cache).
+    Today it does move: the inserted i32 value sorts before the i64 value by stable_key, and the
+    dense bump allocator pushes the i64 slot from offset 0 to offset 8.
+    """
+    monkeypatch.setenv("QD_DUMP_IR", "1")
+    qd.lang.impl.current_cfg().debug_dump_path = str(tmp_path)
+
+    n = 64
+
+    @qd.kernel
+    def gtmp_only_big(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        b = qd.cast(0, qd.i64)  # a single i64 cross-offload value
+        for i in range(5):
+            b += qd.cast(i * i, qd.i64)
+        for i in range(n):
+            out[i] = qd.cast(b, qd.i32) + i
+
+    @qd.kernel
+    def gtmp_big_and_small(out: qd.types.ndarray(dtype=qd.i32, ndim=1)):
+        b = qd.cast(0, qd.i64)  # the identical i64 value...
+        for i in range(5):
+            b += qd.cast(i * i, qd.i64)
+        a = 0  # ...plus an unrelated i32 value inserted elsewhere in the kernel
+        for i in range(3):
+            a += i
+        for i in range(n):
+            out[i] = qd.cast(b, qd.i32) + a + i
+
+    out = qd.ndarray(qd.i32, shape=(n,))
+    gtmp_only_big(out)
+    qd.sync()
+    gtmp_big_and_small(out)
+    qd.sync()
+
+    off_only = _gtmp_offsets_by_type(tmp_path, "gtmp_only_big")
+    off_both = _gtmp_offsets_by_type(tmp_path, "gtmp_big_and_small")
+
+    # Scenario sanity: the i64 value is present in both, and the extra i32 value only in the second.
+    assert "i64" in off_only and "i64" in off_both, (off_only, off_both)
+    assert "i32" in off_both, off_both
+    # The desired (not-yet-achieved) property: the i64 value's offset is unaffected by the unrelated
+    # i32 value. This currently fails (0 vs 8), which is why the test is marked xfail.
+    assert off_only["i64"] == off_both["i64"], (off_only, off_both)


### PR DESCRIPTION
## What

Global-temp offsets were handed out in offload traversal order, so editing one construct shifted every downstream
slot and changed the IR of tasks that had not themselves changed. Order the collected cross-offload values by a
recursive, offset-free hash of their operand-def DAG first, making a slot's offset a function of *what the value
is* rather than where it fell in traversal order.

## Why

This is a prerequisite for per-task compile caching (the rest of that stack follows). Without a stable offset
policy, an edit to one part of a kernel perturbs the offsets baked into unrelated tasks, so every task's cache key
is invalidated by any edit and per-task caching buys nothing. It is a self-contained change and stands on its own.

## Notes

The ordering hash is offset-free and content-only (statement kind, type, constant/arg identity, operand
structure), memoised so shared subexpressions are hashed once. Slot assignment is deferred to a post-collection
pass so it can consume that stable order.

Part of the per-offload compile-cache work; independent of the other refs and safe to land first.

Made with [Cursor](https://cursor.com)