### PR TITLE
[Cache] Assemble CUDA kernels from per-task modules via a composite JITModule

### DIFF
--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -10,19 +10,7 @@ Whether the compilation caches **persist on disk across Python invocations**. De
 
 Setting `offline_cache=False` is intended to emulate cold-start, i.e. a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
-When `offline_cache=True`, four persistent layers cooperate. The first three share the cache directory configured by `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`); the fourth is owned by libcuda and lives outside that path.
-
-1. The cross-backend kernel-IR / compiled-kernel cache (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded from disk and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
-2. The CUDA per-arch PTX cache, written under `<offline_cache_file_path>/ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and the LLVM-to-PTX compilation pipeline (LLVM optimization passes plus the NVPTX backend's PTX emission) is skipped.
-3. The CUDA per-task relocatable-cubin cache, written under `<offline_cache_file_path>/culink_cubins_sm_*`. On the per-task cuLink assembly path each offloaded task's PTX is assembled to a relocatable cubin with `ptxas -c` and cached by content hash; a warm run with an unchanged task then skips both PTX emission and `ptxas` for it. The directory is namespaced by SM version because `ptxas` output is not portable across GPUs. (On the older whole-module path `ptxas` instead runs later inside `cuModuleLoadDataEx`, governed entirely by Layer 4.)
-4. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, `ptxas` work is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
-
-Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) disables every disk-persistent layer so a fresh Python session sees a true cold start:
-
-- Layer 1 falls back to memory-only. The disk cache is not consulted for kernel data and new kernels are not persisted, so kernels are compiled from source on every Python invocation.
-- Layer 2 falls back to memory-only. PTX is still cached within one process so kernels with identical LLVM IR share PTX output, but nothing is read from or written to disk.
-- Layer 3 falls back to memory-only. Each task's cubin is still assembled in the current process, but nothing is read from or written to disk, so a later process cannot be served a cubin this one built.
-- Layer 4 cannot be controlled by the libcuda environment variable `CUDA_CACHE_DISABLE` from inside Python because the variable is captured by libcuda at process start. Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
+When `offline_cache=True`, compilation artifacts persist on disk under `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`), so a later Python process reuses them instead of recompiling. Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) forces a true cold start: nothing is read from or written to disk, and kernels are recompiled on the next invocation.
 
 When to set it to `False`:
 - Taking compile-time profiles where any cached SASS would mask the real cost.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -10,17 +10,19 @@ Whether the compilation caches **persist on disk across Python invocations**. De
 
 Setting `offline_cache=False` is intended to emulate cold-start, i.e. a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
-When `offline_cache=True`, three persistent layers cooperate. The first two share the cache directory configured by `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`); the third is owned by libcuda and lives outside that path.
+When `offline_cache=True`, four persistent layers cooperate. The first three share the cache directory configured by `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`); the fourth is owned by libcuda and lives outside that path.
 
 1. The cross-backend kernel-IR / compiled-kernel cache (driven by `KernelCompilationManager`). When the IR-and-config hash hits, the previously compiled kernel data is loaded from disk and the entire compile pipeline is skipped. Active for every backend (CPU, CUDA, AMDGPU, Metal, Vulkan).
-2. The CUDA per-arch PTX cache, written under `<offline_cache_file_path>/ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and the LLVM-to-PTX compilation pipeline (LLVM optimization passes plus the NVPTX backend's PTX emission) is skipped. `ptxas` itself runs later inside `cuModuleLoadDataEx` and is governed by Layer 3.
-3. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, `ptxas` work is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
+2. The CUDA per-arch PTX cache, written under `<offline_cache_file_path>/ptx_cache_sm_*` (driven by `PtxCache`). When the LLVM-IR hash hits, the previously emitted PTX is loaded from disk and the LLVM-to-PTX compilation pipeline (LLVM optimization passes plus the NVPTX backend's PTX emission) is skipped.
+3. The CUDA per-task relocatable-cubin cache, written under `<offline_cache_file_path>/culink_cubins_sm_*`. On the per-task cuLink assembly path each offloaded task's PTX is assembled to a relocatable cubin with `ptxas -c` and cached by content hash; a warm run with an unchanged task then skips both PTX emission and `ptxas` for it. The directory is namespaced by SM version because `ptxas` output is not portable across GPUs. (On the older whole-module path `ptxas` instead runs later inside `cuModuleLoadDataEx`, governed entirely by Layer 4.)
+4. The NVIDIA driver compute cache at `~/.nv/ComputeCache`, keyed by PTX content hash. When this hits, `ptxas` work is skipped because the SASS itself is reused. This cache is owned by libcuda and not by Quadrants.
 
 Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) disables every disk-persistent layer so a fresh Python session sees a true cold start:
 
 - Layer 1 falls back to memory-only. The disk cache is not consulted for kernel data and new kernels are not persisted, so kernels are compiled from source on every Python invocation.
 - Layer 2 falls back to memory-only. PTX is still cached within one process so kernels with identical LLVM IR share PTX output, but nothing is read from or written to disk.
-- Layer 3 cannot be controlled by the libcuda environment variable `CUDA_CACHE_DISABLE` from inside Python because the variable is captured by libcuda at process start. Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
+- Layer 3 falls back to memory-only. Each task's cubin is still assembled in the current process, but nothing is read from or written to disk, so a later process cannot be served a cubin this one built.
+- Layer 4 cannot be controlled by the libcuda environment variable `CUDA_CACHE_DISABLE` from inside Python because the variable is captured by libcuda at process start. Quadrants instead appends a per-process nonce comment to the PTX it submits to `cuModuleLoadDataEx`. The nonce is constant within one process - kernels with identical PTX still share a cubin in the same run - and changes between processes so cross-run hits cannot quietly serve stale SASS.
 
 When to set it to `False`:
 - Taking compile-time profiles where any cached SASS would mask the real cost.

--- a/docs/source/user_guide/init_options.md
+++ b/docs/source/user_guide/init_options.md
@@ -10,7 +10,7 @@ Whether the compilation caches **persist on disk across Python invocations**. De
 
 Setting `offline_cache=False` is intended to emulate cold-start, i.e. a fresh Python process with no prior on-disk artifacts available. In-process caches operate independently of this flag: within a single Python session, identical kernels are never recompiled. The flag therefore controls only whether the next Python invocation observes a warm or a cold disk.
 
-When `offline_cache=True`, compilation artifacts persist on disk under `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`), so a later Python process reuses them instead of recompiling. Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) forces a true cold start: nothing is read from or written to disk, and kernels are recompiled on the next invocation.
+When `offline_cache=True`, compilation artifacts persist on disk under `offline_cache_file_path` (default `~/.cache/quadrants/qdcache`), so a later Python process reuses them instead of recompiling. Setting `offline_cache=False` (or `QD_OFFLINE_CACHE=0`) forces a cold start: Quadrants recompiles kernels and neither reads nor writes its own on-disk cache. (On CUDA the driver keeps a separate SASS cache at `~/.nv/ComputeCache` that this flag does not disable; `offline_cache=False` only stops that cache from serving results across runs. Set `CUDA_CACHE_DISABLE=1` to turn it off entirely.)
 
 When to set it to `False`:
 - Taking compile-time profiles where any cached SASS would mask the real cost.

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -77,18 +77,22 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   }
   worker.flush();
 
-  // Per-task path: one self-contained module per task, built BEFORE the whole-module link consumes `data`.
+  // Per-task path (CUDA-only): one self-contained module per task, built BEFORE the whole-module link consumes
+  // `data`. Only the CUDA launcher consumes per_construct_artifacts, so gate on CUDA to avoid paying an extra
+  // per-task link + optimize on CPU / AMDGPU (7 and 8 extend consumption to those backends).
   std::vector<PerConstructArtifact> per_construct_artifacts;
-  for (int i = 0; i < (int)data.size(); i++) {
-    if (!data[i] || !data[i]->module)
-      continue;
-    PerConstructArtifact art;
-    std::vector<std::unique_ptr<LLVMCompiledTask>> one;
-    one.push_back(std::make_unique<LLVMCompiledTask>(data[i]->clone()));
-    auto linked_one = tlctx_.link_compiled_tasks(std::move(one));
-    optimize_module(linked_one.module.get());
-    art.module = std::move(linked_one.module);
-    per_construct_artifacts.push_back(std::move(art));
+  if (compile_config_.arch == Arch::cuda) {
+    for (int i = 0; i < (int)data.size(); i++) {
+      if (!data[i] || !data[i]->module)
+        continue;
+      PerConstructArtifact art;
+      std::vector<std::unique_ptr<LLVMCompiledTask>> one;
+      one.push_back(std::make_unique<LLVMCompiledTask>(data[i]->clone()));
+      auto linked_one = tlctx_.link_compiled_tasks(std::move(one));
+      optimize_module(linked_one.module.get());
+      art.module = std::move(linked_one.module);
+      per_construct_artifacts.push_back(std::move(art));
+    }
   }
 
   auto llvm_compiled_kernel = tlctx_.link_compiled_tasks(std::move(data));

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -77,10 +77,7 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   }
   worker.flush();
 
-  // Per-task cuLink path: produce one self-contained module per offloaded task -- link its runtime deps and optimize
-  // it -- BEFORE the whole-module link consumes `data`. These flow to the CUDA JIT, which compiles each to a
-  // relocatable cubin (hitting the on-disk cubin cache when the task is unchanged) and `cuLink`s them into one
-  // CUmodule.
+  // Per-task cuLink path: one self-contained module per task, built BEFORE the whole-module link consumes `data`.
   std::vector<PerConstructArtifact> per_construct_artifacts;
   for (int i = 0; i < (int)data.size(); i++) {
     if (!data[i] || !data[i]->module)

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -17,8 +17,6 @@
 #include "quadrants/ir/transforms.h"
 #include "quadrants/analysis/offline_cache_util.h"
 
-#include <algorithm>
-
 namespace quadrants::lang {
 
 KernelCodeGen::KernelCodeGen(const CompileConfig &compile_config,
@@ -79,8 +77,8 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   }
   worker.flush();
 
-  // Per-task cuLink path: produce one self-contained artifact per offloaded task -- link its runtime deps and
-  // optimize it -- BEFORE the whole-module link consumes `data`. These flow to the CUDA JIT, which compiles each to a
+  // Per-task cuLink path: produce one self-contained module per offloaded task -- link its runtime deps and optimize
+  // it -- BEFORE the whole-module link consumes `data`. These flow to the CUDA JIT, which compiles each to a
   // relocatable cubin (hitting the on-disk cubin cache when the task is unchanged) and `cuLink`s them into one
   // CUmodule.
   std::vector<PerConstructArtifact> per_construct_artifacts;
@@ -93,13 +91,6 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
     auto linked_one = tlctx_.link_compiled_tasks(std::move(one));
     optimize_module(linked_one.module.get());
     art.module = std::move(linked_one.module);
-    // Carry the launch/graph metadata down to the JIT: the cubin alone cannot be launched.
-    art.tasks = linked_one.tasks;
-    // Sorted for deterministic on-disk bytes (these are unordered_sets upstream).
-    art.used_tree_ids.assign(data[i]->used_tree_ids.begin(), data[i]->used_tree_ids.end());
-    art.struct_for_tls_sizes.assign(data[i]->struct_for_tls_sizes.begin(), data[i]->struct_for_tls_sizes.end());
-    std::sort(art.used_tree_ids.begin(), art.used_tree_ids.end());
-    std::sort(art.struct_for_tls_sizes.begin(), art.struct_for_tls_sizes.end());
     per_construct_artifacts.push_back(std::move(art));
   }
 

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -77,7 +77,7 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   }
   worker.flush();
 
-  // Per-task cuLink path: one self-contained module per task, built BEFORE the whole-module link consumes `data`.
+  // Per-task path: one self-contained module per task, built BEFORE the whole-module link consumes `data`.
   std::vector<PerConstructArtifact> per_construct_artifacts;
   for (int i = 0; i < (int)data.size(); i++) {
     if (!data[i] || !data[i]->module)

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -17,6 +17,8 @@
 #include "quadrants/ir/transforms.h"
 #include "quadrants/analysis/offline_cache_util.h"
 
+#include <algorithm>
+
 namespace quadrants::lang {
 
 KernelCodeGen::KernelCodeGen(const CompileConfig &compile_config,
@@ -77,8 +79,33 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   }
   worker.flush();
 
+  // Per-task cuLink path: produce one self-contained artifact per offloaded task -- link its runtime deps and
+  // optimize it -- BEFORE the whole-module link consumes `data`. These flow to the CUDA JIT, which compiles each to a
+  // relocatable cubin (hitting the on-disk cubin cache when the task is unchanged) and `cuLink`s them into one
+  // CUmodule.
+  std::vector<PerConstructArtifact> per_construct_artifacts;
+  for (int i = 0; i < (int)data.size(); i++) {
+    if (!data[i] || !data[i]->module)
+      continue;
+    PerConstructArtifact art;
+    std::vector<std::unique_ptr<LLVMCompiledTask>> one;
+    one.push_back(std::make_unique<LLVMCompiledTask>(data[i]->clone()));
+    auto linked_one = tlctx_.link_compiled_tasks(std::move(one));
+    optimize_module(linked_one.module.get());
+    art.module = std::move(linked_one.module);
+    // Carry the launch/graph metadata down to the JIT: the cubin alone cannot be launched.
+    art.tasks = linked_one.tasks;
+    // Sorted for deterministic on-disk bytes (these are unordered_sets upstream).
+    art.used_tree_ids.assign(data[i]->used_tree_ids.begin(), data[i]->used_tree_ids.end());
+    art.struct_for_tls_sizes.assign(data[i]->struct_for_tls_sizes.begin(), data[i]->struct_for_tls_sizes.end());
+    std::sort(art.used_tree_ids.begin(), art.used_tree_ids.end());
+    std::sort(art.struct_for_tls_sizes.begin(), art.struct_for_tls_sizes.end());
+    per_construct_artifacts.push_back(std::move(art));
+  }
+
   auto llvm_compiled_kernel = tlctx_.link_compiled_tasks(std::move(data));
   optimize_module(llvm_compiled_kernel.module.get());
+  llvm_compiled_kernel.per_construct_artifacts = std::move(per_construct_artifacts);
   return llvm_compiled_kernel;
 }
 

--- a/quadrants/codegen/cuda/codegen_cuda.cpp
+++ b/quadrants/codegen/cuda/codegen_cuda.cpp
@@ -162,6 +162,13 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
       size_t shared_array_bytes = tensor_type->get_num_elements() * data_type_size(tensor_type->get_element_type());
 
       llvm::Type *shared_array_type;
+      // Linkage of the addrspace(3) shared global. Static (sized) shared scratch is emitted as an internal
+      // *definition* (undef init) rather than an external declaration: in whole-program compilation ptxas ignores the
+      // extern qualifier (warns "Unresolved extern variable ... ignoring extern qualifier"), but the `.extern .shared`
+      // form is an unresolved symbol under relocatable device linking (`ptxas -c` + `cuLink`), which the
+      // per-task cubin path requires. Dynamic shared memory (zero-sized, runtime-sized at launch)
+      // is inherently `extern __shared__` and must stay external.
+      llvm::GlobalValue::LinkageTypes shared_linkage = llvm::GlobalValue::InternalLinkage;
       if (shared_array_bytes > cuda_dynamic_shared_array_threshold_bytes) {
         if (dynamic_shared_array_bytes > 0) {
           /* Current version only allows one dynamic shared array allocation,
@@ -193,13 +200,16 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
         auto element_type = tlctx->get_data_type(tensor_type->get_element_type());
         shared_array_type = llvm::ArrayType::get(element_type, 0);
         dynamic_shared_array_bytes += shared_array_bytes;
+        shared_linkage = llvm::GlobalValue::ExternalLinkage;  // dynamic shared mem: inherently extern
       } else {
         shared_array_type = tlctx->get_data_type(tensor_type);
       }
 
-      auto base = new llvm::GlobalVariable(*module, shared_array_type, false, llvm::GlobalValue::ExternalLinkage,
-                                           nullptr, fmt::format("shared_array_t{}_s{}", task_codegen_id, stmt->id),
-                                           nullptr, llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
+      llvm::Constant *shared_init =
+          (shared_linkage == llvm::GlobalValue::InternalLinkage) ? llvm::UndefValue::get(shared_array_type) : nullptr;
+      auto base = new llvm::GlobalVariable(*module, shared_array_type, false, shared_linkage, shared_init,
+                                           fmt::format("shared_array_t{}_s{}", task_codegen_id, stmt->id), nullptr,
+                                           llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
       base->setAlignment(llvm::MaybeAlign(8));
       auto ptr_shared_array_type = llvm::PointerType::get(shared_array_type, 0);
       llvm_val[stmt] = builder->CreatePointerCast(base, ptr_shared_array_type);
@@ -611,8 +621,14 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
   void create_bls_buffer(OffloadedStmt *stmt) {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context), stmt->bls_size);
-    bls_buffer = new GlobalVariable(*module, type, false, llvm::GlobalValue::ExternalLinkage, nullptr, "bls_buffer",
-                                    nullptr, llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
+    // Internal definition rather than an external declaration, for the same reason as the static shared scratch in
+    // `visit(AllocaStmt *)` above: `.extern .shared` is an unresolved symbol under relocatable device linking
+    // (`ptxas -c` + `cuLink`), so a per-task cubin referencing it fails cuLinkComplete with "Undefined reference to
+    // 'bls_buffer'". BLS is always statically sized (`bls_size`, and this is only reached when it is non-zero), so
+    // it never needs the runtime-sized `extern __shared__` form.
+    bls_buffer = new GlobalVariable(*module, type, false, llvm::GlobalValue::InternalLinkage,
+                                    llvm::UndefValue::get(type), "bls_buffer", nullptr,
+                                    llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
     bls_buffer->setAlignment(llvm::MaybeAlign(8));
   }
 

--- a/quadrants/codegen/cuda/codegen_cuda.cpp
+++ b/quadrants/codegen/cuda/codegen_cuda.cpp
@@ -162,8 +162,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
       size_t shared_array_bytes = tensor_type->get_num_elements() * data_type_size(tensor_type->get_element_type());
 
       llvm::Type *shared_array_type;
-      // Static shared scratch: internal definition, not `.extern .shared` (unresolved under `ptxas -c` + cuLink).
-      // Dynamic shared mem (runtime-sized) is inherently `extern __shared__` and stays external.
+      // Emit static shared scratch as an internal *definition* so each per-task module is self-contained, instead of
+      // an `.extern .shared` declaration that only resolves via ptxas's whole-module "ignore extern qualifier"
+      // fallback. Dynamic shared mem (runtime-sized) is inherently `extern __shared__` and stays external.
       llvm::GlobalValue::LinkageTypes shared_linkage = llvm::GlobalValue::InternalLinkage;
       if (shared_array_bytes > cuda_dynamic_shared_array_threshold_bytes) {
         if (dynamic_shared_array_bytes > 0) {
@@ -617,8 +618,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
   void create_bls_buffer(OffloadedStmt *stmt) {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context), stmt->bls_size);
-    // Internal definition, like the static shared scratch above: `.extern .shared` fails cuLink. BLS is always
-    // statically sized, so it never needs the runtime-sized `extern __shared__` form.
+    // Internal definition, like the static shared scratch above, so each per-task module self-contains its BLS
+    // storage rather than leaning on the `.extern .shared` fallback. BLS is always statically sized, so it never
+    // needs the runtime-sized `extern __shared__` form.
     bls_buffer =
         new GlobalVariable(*module, type, false, llvm::GlobalValue::InternalLinkage, llvm::UndefValue::get(type),
                            "bls_buffer", nullptr, llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);

--- a/quadrants/codegen/cuda/codegen_cuda.cpp
+++ b/quadrants/codegen/cuda/codegen_cuda.cpp
@@ -619,9 +619,9 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context), stmt->bls_size);
     // Internal definition, like the static shared scratch above: `.extern .shared` fails cuLink. BLS is always
     // statically sized, so it never needs the runtime-sized `extern __shared__` form.
-    bls_buffer = new GlobalVariable(*module, type, false, llvm::GlobalValue::InternalLinkage,
-                                    llvm::UndefValue::get(type), "bls_buffer", nullptr,
-                                    llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
+    bls_buffer =
+        new GlobalVariable(*module, type, false, llvm::GlobalValue::InternalLinkage, llvm::UndefValue::get(type),
+                           "bls_buffer", nullptr, llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);
     bls_buffer->setAlignment(llvm::MaybeAlign(8));
   }
 

--- a/quadrants/codegen/cuda/codegen_cuda.cpp
+++ b/quadrants/codegen/cuda/codegen_cuda.cpp
@@ -162,12 +162,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
       size_t shared_array_bytes = tensor_type->get_num_elements() * data_type_size(tensor_type->get_element_type());
 
       llvm::Type *shared_array_type;
-      // Linkage of the addrspace(3) shared global. Static (sized) shared scratch is emitted as an internal
-      // *definition* (undef init) rather than an external declaration: in whole-program compilation ptxas ignores the
-      // extern qualifier (warns "Unresolved extern variable ... ignoring extern qualifier"), but the `.extern .shared`
-      // form is an unresolved symbol under relocatable device linking (`ptxas -c` + `cuLink`), which the
-      // per-task cubin path requires. Dynamic shared memory (zero-sized, runtime-sized at launch)
-      // is inherently `extern __shared__` and must stay external.
+      // Static shared scratch: internal definition, not `.extern .shared` (unresolved under `ptxas -c` + cuLink).
+      // Dynamic shared mem (runtime-sized) is inherently `extern __shared__` and stays external.
       llvm::GlobalValue::LinkageTypes shared_linkage = llvm::GlobalValue::InternalLinkage;
       if (shared_array_bytes > cuda_dynamic_shared_array_threshold_bytes) {
         if (dynamic_shared_array_bytes > 0) {
@@ -621,11 +617,8 @@ class TaskCodeGenCUDA : public TaskCodeGenLLVM {
 
   void create_bls_buffer(OffloadedStmt *stmt) {
     auto type = llvm::ArrayType::get(llvm::Type::getInt8Ty(*llvm_context), stmt->bls_size);
-    // Internal definition rather than an external declaration, for the same reason as the static shared scratch in
-    // `visit(AllocaStmt *)` above: `.extern .shared` is an unresolved symbol under relocatable device linking
-    // (`ptxas -c` + `cuLink`), so a per-task cubin referencing it fails cuLinkComplete with "Undefined reference to
-    // 'bls_buffer'". BLS is always statically sized (`bls_size`, and this is only reached when it is non-zero), so
-    // it never needs the runtime-sized `extern __shared__` form.
+    // Internal definition, like the static shared scratch above: `.extern .shared` fails cuLink. BLS is always
+    // statically sized, so it never needs the runtime-sized `extern __shared__` form.
     bls_buffer = new GlobalVariable(*module, type, false, llvm::GlobalValue::InternalLinkage,
                                     llvm::UndefValue::get(type), "bls_buffer", nullptr,
                                     llvm::GlobalVariable::NotThreadLocal, 3 /*addrspace=shared*/);

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -3467,8 +3467,7 @@ LLVMCompiledTask LLVMCompiledTask::clone() const {
 
 LLVMCompiledKernel LLVMCompiledKernel::clone() const {
   LLVMCompiledKernel result{tasks, llvm::CloneModule(*module)};
-  // The launcher consumes a clone, so the per-task modules must travel with it: dropping them would make the cuLink
-  // path see no artifacts and silently fall back to the whole-module load.
+  // The launcher consumes a clone, so the per-task modules must travel with it.
   result.per_construct_artifacts.reserve(per_construct_artifacts.size());
   for (auto &a : per_construct_artifacts) {
     PerConstructArtifact c;

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -3467,16 +3467,12 @@ LLVMCompiledTask LLVMCompiledTask::clone() const {
 
 LLVMCompiledKernel LLVMCompiledKernel::clone() const {
   LLVMCompiledKernel result{tasks, llvm::CloneModule(*module)};
-  // The launcher consumes a clone, so the per-task artifacts (code + launch metadata) must travel with it: dropping
-  // them would make the cuLink path see no artifacts and silently fall back to the whole-module load.
+  // The launcher consumes a clone, so the per-task modules must travel with it: dropping them would make the cuLink
+  // path see no artifacts and silently fall back to the whole-module load.
   result.per_construct_artifacts.reserve(per_construct_artifacts.size());
   for (auto &a : per_construct_artifacts) {
     PerConstructArtifact c;
     c.module = a.module ? llvm::CloneModule(*a.module) : nullptr;
-    c.cubin = a.cubin;
-    c.tasks = a.tasks;
-    c.used_tree_ids = a.used_tree_ids;
-    c.struct_for_tls_sizes = a.struct_for_tls_sizes;
     result.per_construct_artifacts.push_back(std::move(c));
   }
   return result;

--- a/quadrants/codegen/llvm/codegen_llvm.cpp
+++ b/quadrants/codegen/llvm/codegen_llvm.cpp
@@ -3466,7 +3466,20 @@ LLVMCompiledTask LLVMCompiledTask::clone() const {
 }
 
 LLVMCompiledKernel LLVMCompiledKernel::clone() const {
-  return {tasks, llvm::CloneModule(*module)};
+  LLVMCompiledKernel result{tasks, llvm::CloneModule(*module)};
+  // The launcher consumes a clone, so the per-task artifacts (code + launch metadata) must travel with it: dropping
+  // them would make the cuLink path see no artifacts and silently fall back to the whole-module load.
+  result.per_construct_artifacts.reserve(per_construct_artifacts.size());
+  for (auto &a : per_construct_artifacts) {
+    PerConstructArtifact c;
+    c.module = a.module ? llvm::CloneModule(*a.module) : nullptr;
+    c.cubin = a.cubin;
+    c.tasks = a.tasks;
+    c.used_tree_ids = a.used_tree_ids;
+    c.struct_for_tls_sizes = a.struct_for_tls_sizes;
+    result.per_construct_artifacts.push_back(std::move(c));
+  }
+  return result;
 }
 
 }  // namespace quadrants::lang

--- a/quadrants/codegen/llvm/llvm_compiled_data.h
+++ b/quadrants/codegen/llvm/llvm_compiled_data.h
@@ -201,15 +201,11 @@ struct LLVMCompiledTask {
   QD_IO_DEF(tasks);
 };
 
-// One entry of the per-task cuLink path: the device code for a single offloaded task, plus the launch / CUDA graph
-// metadata the JIT carries alongside it. Built per task in `KernelCodeGen::compile_kernel_to_module`; consumed by the
-// CUDA JIT, which assembles each `module` to a relocatable cubin and `cuLink`s them into one CUmodule.
+// One self-contained module of the per-task cuLink path: the device code for a single offloaded task. Built per task
+// in `KernelCodeGen::compile_kernel_to_module`; the CUDA JIT assembles each to a relocatable cubin and `cuLink`s them
+// into one CUmodule.
 struct PerConstructArtifact {
   std::unique_ptr<llvm::Module> module{nullptr};
-  std::vector<char> cubin;
-  std::vector<OffloadedTask> tasks;
-  std::vector<int> used_tree_ids;
-  std::vector<int> struct_for_tls_sizes;
 };
 
 struct LLVMCompiledKernel {

--- a/quadrants/codegen/llvm/llvm_compiled_data.h
+++ b/quadrants/codegen/llvm/llvm_compiled_data.h
@@ -201,9 +201,7 @@ struct LLVMCompiledTask {
   QD_IO_DEF(tasks);
 };
 
-// One self-contained module of the per-task cuLink path: the device code for a single offloaded task. Built per task
-// in `KernelCodeGen::compile_kernel_to_module`; the CUDA JIT assembles each to a relocatable cubin and `cuLink`s them
-// into one CUmodule.
+// One offloaded task's self-contained module, for the per-task cuLink path.
 struct PerConstructArtifact {
   std::unique_ptr<llvm::Module> module{nullptr};
 };
@@ -211,8 +209,7 @@ struct PerConstructArtifact {
 struct LLVMCompiledKernel {
   std::vector<OffloadedTask> tasks;
   std::unique_ptr<llvm::Module> module{nullptr};
-  // Per-task self-contained artifacts for the relocatable-cubin + cuLink path. Empty => the JIT uses the whole-module
-  // `module`. Transient (not part of QD_IO_DEF).
+  // Per-task modules for the cuLink path; empty => JIT uses the whole-module `module`. Transient (not in QD_IO_DEF).
   std::vector<PerConstructArtifact> per_construct_artifacts;
   LLVMCompiledKernel() = default;
   LLVMCompiledKernel(LLVMCompiledKernel &&) = default;

--- a/quadrants/codegen/llvm/llvm_compiled_data.h
+++ b/quadrants/codegen/llvm/llvm_compiled_data.h
@@ -201,7 +201,7 @@ struct LLVMCompiledTask {
   QD_IO_DEF(tasks);
 };
 
-// One offloaded task's self-contained module, for the per-task cuLink path.
+// One offloaded task's self-contained module, for the per-task module path.
 struct PerConstructArtifact {
   std::unique_ptr<llvm::Module> module{nullptr};
 };
@@ -209,7 +209,7 @@ struct PerConstructArtifact {
 struct LLVMCompiledKernel {
   std::vector<OffloadedTask> tasks;
   std::unique_ptr<llvm::Module> module{nullptr};
-  // Per-task modules for the cuLink path; empty => JIT uses the whole-module `module`. Transient (not in QD_IO_DEF).
+  // Per-task modules for the per-task path; empty => JIT uses the whole-module `module`. Transient (not in QD_IO_DEF).
   std::vector<PerConstructArtifact> per_construct_artifacts;
   LLVMCompiledKernel() = default;
   LLVMCompiledKernel(LLVMCompiledKernel &&) = default;

--- a/quadrants/codegen/llvm/llvm_compiled_data.h
+++ b/quadrants/codegen/llvm/llvm_compiled_data.h
@@ -201,9 +201,23 @@ struct LLVMCompiledTask {
   QD_IO_DEF(tasks);
 };
 
+// One entry of the per-task cuLink path: the device code for a single offloaded task, plus the launch / CUDA graph
+// metadata the JIT carries alongside it. Built per task in `KernelCodeGen::compile_kernel_to_module`; consumed by the
+// CUDA JIT, which assembles each `module` to a relocatable cubin and `cuLink`s them into one CUmodule.
+struct PerConstructArtifact {
+  std::unique_ptr<llvm::Module> module{nullptr};
+  std::vector<char> cubin;
+  std::vector<OffloadedTask> tasks;
+  std::vector<int> used_tree_ids;
+  std::vector<int> struct_for_tls_sizes;
+};
+
 struct LLVMCompiledKernel {
   std::vector<OffloadedTask> tasks;
   std::unique_ptr<llvm::Module> module{nullptr};
+  // Per-task self-contained artifacts for the relocatable-cubin + cuLink path. Empty => the JIT uses the whole-module
+  // `module`. Transient (not part of QD_IO_DEF).
+  std::vector<PerConstructArtifact> per_construct_artifacts;
   LLVMCompiledKernel() = default;
   LLVMCompiledKernel(LLVMCompiledKernel &&) = default;
   LLVMCompiledKernel &operator=(LLVMCompiledKernel &&) = default;

--- a/quadrants/jit/jit_session.h
+++ b/quadrants/jit/jit_session.h
@@ -6,7 +6,9 @@
 #include "quadrants/runtime/llvm/llvm_fwd.h"
 #include "quadrants/util/lang_util.h"
 #include "quadrants/jit/jit_module.h"
+#ifdef QD_WITH_LLVM
 #include "quadrants/codegen/llvm/llvm_compiled_data.h"  // PerConstructArtifact (per-task module path)
+#endif
 
 namespace quadrants::lang {
 
@@ -28,11 +30,15 @@ class JITSession {
 
   virtual JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg = 0) = 0;
 
+#ifdef QD_WITH_LLVM
   // Per-task path: compile each self-contained artifact to a loadable module and expose them behind one composite
-  // JITModule that resolves tasks by name. CUDA-only; the default errors.
+  // JITModule that resolves tasks by name. CUDA-only; the default errors. Gated on QD_WITH_LLVM because the parameter's
+  // inline default body needs PerConstructArtifact complete (i.e. the llvm_compiled_data.h include above), which pulls
+  // in real LLVM headers unavailable in a QD_WITH_LLVM=OFF (Vulkan/Metal-only) build of this generic JIT header.
   virtual JITModule *add_module_per_task(std::vector<PerConstructArtifact> artifacts, int max_reg = 0) {
     QD_NOT_IMPLEMENTED
   }
+#endif
 
   // virtual void remove_module(JITModule *module) = 0;
 

--- a/quadrants/jit/jit_session.h
+++ b/quadrants/jit/jit_session.h
@@ -28,9 +28,8 @@ class JITSession {
 
   virtual JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg = 0) = 0;
 
-  // Per-task cubin path: assemble one JIT module from several self-contained sub-modules by emitting a relocatable
-  // cubin per sub-module and device-linking them (`cuLink`). Only the CUDA backend implements this; the default
-  // errors so other backends are unaffected. Each artifact is one offloaded task, plus its launch metadata.
+  // Per-task cubin path: one relocatable cubin per artifact, device-linked (`cuLink`) into one module. CUDA-only;
+  // the default errors.
   virtual JITModule *add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg = 0) {
     QD_NOT_IMPLEMENTED
   }

--- a/quadrants/jit/jit_session.h
+++ b/quadrants/jit/jit_session.h
@@ -6,7 +6,7 @@
 #include "quadrants/runtime/llvm/llvm_fwd.h"
 #include "quadrants/util/lang_util.h"
 #include "quadrants/jit/jit_module.h"
-#include "quadrants/codegen/llvm/llvm_compiled_data.h"  // PerConstructArtifact (per-task cuLink path)
+#include "quadrants/codegen/llvm/llvm_compiled_data.h"  // PerConstructArtifact (per-task module path)
 
 namespace quadrants::lang {
 
@@ -28,9 +28,9 @@ class JITSession {
 
   virtual JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg = 0) = 0;
 
-  // Per-task cubin path: one relocatable cubin per artifact, device-linked (`cuLink`) into one module. CUDA-only;
-  // the default errors.
-  virtual JITModule *add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg = 0) {
+  // Per-task path: compile each self-contained artifact to a loadable module and expose them behind one composite
+  // JITModule that resolves tasks by name. CUDA-only; the default errors.
+  virtual JITModule *add_module_per_task(std::vector<PerConstructArtifact> artifacts, int max_reg = 0) {
     QD_NOT_IMPLEMENTED
   }
 

--- a/quadrants/jit/jit_session.h
+++ b/quadrants/jit/jit_session.h
@@ -6,6 +6,7 @@
 #include "quadrants/runtime/llvm/llvm_fwd.h"
 #include "quadrants/util/lang_util.h"
 #include "quadrants/jit/jit_module.h"
+#include "quadrants/codegen/llvm/llvm_compiled_data.h"  // PerConstructArtifact (per-task cuLink path)
 
 namespace quadrants::lang {
 
@@ -26,6 +27,13 @@ class JITSession {
   JITSession(QuadrantsLLVMContext *tlctx, const CompileConfig &config);
 
   virtual JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg = 0) = 0;
+
+  // Per-task cubin path: assemble one JIT module from several self-contained sub-modules by emitting a relocatable
+  // cubin per sub-module and device-linking them (`cuLink`). Only the CUDA backend implements this; the default
+  // errors so other backends are unaffected. Each artifact is one offloaded task, plus its launch metadata.
+  virtual JITModule *add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg = 0) {
+    QD_NOT_IMPLEMENTED
+  }
 
   // virtual void remove_module(JITModule *module) = 0;
 

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -1,5 +1,9 @@
+#include <atomic>
 #include <chrono>
+#include <iterator>
+#include <mutex>
 #include <random>
+#include <vector>
 
 #include "quadrants/runtime/cuda/jit_cuda.h"
 #include "quadrants/runtime/llvm/llvm_context.h"
@@ -177,6 +181,179 @@ JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_r
   // cudaModules.push_back(cudaModule);
   modules.push_back(std::make_unique<JITModuleCUDA>(cuda_module));
   return modules.back().get();
+}
+
+// Emit a *relocatable* cubin from PTX via `ptxas -c` (shell-out; production would link libnvptxcompiler_static).
+// Relocatable is mandatory: an executable cubin cannot be re-linked by cuLink, which rejects it with err 209.
+// Temp files under the system temp dir, cleaned up.
+static std::vector<char> ptx_to_relocatable_cubin(const std::string &ptx, const std::string &arch) {
+  namespace fs = std::filesystem;
+  static std::atomic<uint64_t> ctr{0};
+  auto now = std::chrono::steady_clock::now().time_since_epoch().count();
+  auto stem = fmt::format("qd_culink_{}_{}", (unsigned long long)now, ctr.fetch_add(1));
+  auto ptx_path = fs::temp_directory_path() / (stem + ".ptx");
+  auto cubin_path = fs::temp_directory_path() / (stem + ".cubin");
+  {
+    // compile_module_to_ptx NUL-terminates the buffer so the driver's cuModuleLoadDataEx gets a C-string image.
+    // ptxas (CUDA 13+) treats an embedded NUL as a premature EOF and aborts, so write only up to the terminator.
+    std::streamsize ptx_len = (std::streamsize)ptx.size();
+    while (ptx_len > 0 && ptx[ptx_len - 1] == '\0')
+      --ptx_len;
+    std::ofstream o(ptx_path, std::ios::binary);
+    o.write(ptx.data(), ptx_len);
+  }
+  auto cmd = fmt::format("ptxas -c -arch={} {} -o {} 2>/dev/null", arch, ptx_path.string(), cubin_path.string());
+  int rc = std::system(cmd.c_str());
+  QD_ERROR_IF(rc != 0, "ptxas -c failed (rc={}) arch={}", rc, arch);
+  std::ifstream in(cubin_path, std::ios::binary);
+  std::vector<char> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  std::error_code ec;
+  fs::remove(ptx_path, ec);
+  fs::remove(cubin_path, ec);
+  return bytes;
+}
+
+// LLVM->PTX stays serialised: the per-task modules are produced on the codegen worker threads and may share an
+// LLVMContext, which is not safe for concurrent codegen.
+static std::mutex g_ptxgen_mu;
+
+// Per-task relocatable-cubin disk cache. A warm run with an unchanged task hits the cache and skips PTX + ptxas
+// entirely. Directory is <offline_cache>/culink_cubins_sm_<cc>, or /tmp/qd_culink_cubins_sm_<cc> when the offline
+// cache path is unset.
+//
+// `offline_cache=False` emulates a cold process, so -- exactly like `PtxCache` and the kernel-data cache -- this
+// falls back to a mem-only build that touches no disk: nothing is read, nothing is written, not even the directory
+// is created. Otherwise a fresh session run with `offline_cache=False` would be served a cubin left by a previous
+// run and would not see the true cold start the flag promises.
+//
+// The key is a hash of the module's LLVM-IR text, which is what makes the cache safe to share across kernels: the
+// text contains the task's entry-point symbol names, so two kernels whose tasks differ only in name cannot collide
+// on one cubin.
+//
+// Cubins are SM-specific (`ptxas -arch=`), so the directory is namespaced by mcpu -- otherwise a cache populated on
+// one GPU would be silently loaded on another. `fast_math` is folded into the key by `make_cache_key`; the rest of
+// the compile config is already folded into the LLVM IR upstream.
+std::vector<char> JITSessionCUDA::get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module) {
+  namespace fs = std::filesystem;
+  const std::string mcpu = CUDAContext::get_instance().get_mcpu();
+  std::error_code ec;
+
+  // Captured before compile_module_to_ptx, which renames functions via convert().
+  const bool dump_ir = get_environ_config(DUMP_IR_ENV.data()) != 0;
+
+  const bool on_disk = config_.offline_cache;
+  std::string cubin_path;
+  if (on_disk) {
+    const std::string leaf = "culink_cubins_" + mcpu;
+    const std::string dir =
+        config_.offline_cache_file_path.empty() ? ("/tmp/qd_" + leaf) : (config_.offline_cache_file_path + "/" + leaf);
+    fs::create_directories(dir, ec);
+
+    std::string llvm_ir_str;
+    llvm::raw_string_ostream os(llvm_ir_str);
+    module->print(os, nullptr);
+    os.flush();
+    const std::string key = ptx_cache_->make_cache_key(llvm_ir_str, config_.fast_math);
+    cubin_path = (fs::path(dir) / (key + ".cubin")).string();
+
+    // The whole-module loader dumps each module's PTX under `debug_dump_path`; this path replaces it for every CUDA
+    // kernel, so it has to dump too or `QD_DUMP_IR=1` silently stops producing PTX. A cached cubin skips PTX
+    // generation altogether, so when dumps are requested bypass the read -- an explicit debug flag should give a
+    // complete set of artifacts rather than whatever survived from an earlier run.
+    if (!dump_ir && fs::exists(cubin_path)) {
+      std::ifstream in(cubin_path, std::ios::binary);
+      return std::vector<char>((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+    }
+  }
+
+  const std::string dump_name = dump_ir ? moduleToDumpName(module.get()) : std::string();
+  std::string ptx;
+  {
+    std::lock_guard<std::mutex> g(g_ptxgen_mu);
+    ptx = compile_module_to_ptx(module);
+  }
+  if (dump_ir && !dump_name.empty()) {
+    fs::path ir_dump_dir = config_.debug_dump_path;
+    fs::create_directories(ir_dump_dir, ec);
+    if (std::ofstream out(ir_dump_dir / (dump_name + ".ptx")); out.is_open()) {
+      out << ptx << std::endl;
+    }
+  }
+  if (on_disk)
+    return assemble_and_store_cubin(ptx, cubin_path);
+  // Mem-only (offline_cache=False): assemble the relocatable cubin without persisting it.
+  return ptx_to_relocatable_cubin(ptx, mcpu);
+}
+
+std::vector<char> JITSessionCUDA::assemble_and_store_cubin(const std::string &ptx, const std::string &cubin_path) {
+  namespace fs = std::filesystem;
+  auto cubin = ptx_to_relocatable_cubin(ptx, CUDAContext::get_instance().get_mcpu());
+  // atomic-ish write via temp + rename so concurrent builders don't read a partial cubin
+  std::error_code ec;
+  auto tmp = cubin_path + fmt::format(".tmp{}", (unsigned long long)std::chrono::steady_clock::now()
+                                                    .time_since_epoch()
+                                                    .count());
+  {
+    std::ofstream o(tmp, std::ios::binary);
+    o.write(cubin.data(), (std::streamsize)cubin.size());
+  }
+  fs::rename(tmp, cubin_path, ec);
+  if (ec)
+    fs::remove(tmp, ec);
+  return cubin;
+}
+
+JITModule *JITSessionCUDA::add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg) {
+  // Emit a cached relocatable cubin per task (`ptxas -c`) and device-link them into one CUmodule, so an unchanged
+  // task skips PTX + ptxas entirely.
+  constexpr uint32 kCuJitInputCubin = 0;
+  constexpr uint32 kCuJitErrorLogBuffer = 5;
+  constexpr uint32 kCuJitErrorLogBufferSizeBytes = 6;
+  auto &drv = CUDADriver::get_instance();
+
+  std::vector<std::vector<char>> cubins;
+  cubins.reserve(artifacts.size());
+  for (auto &art : artifacts) {
+    cubins.push_back(get_or_build_construct_cubin(art.module));
+  }
+
+  CUDAContext::get_instance().make_current();
+  [[maybe_unused]] auto _ = CUDAContext::get_instance().get_lock_guard();
+
+  std::vector<char> err_log(8192, 0);
+  std::size_t err_sz = err_log.size();
+  uint32 link_opts[3];
+  void *link_optvals[3];
+  int n_lopt = 0;
+  if (max_reg != 0) {
+    link_opts[n_lopt] = CU_JIT_MAX_REGISTERS;
+    link_optvals[n_lopt++] = &max_reg;
+  }
+  link_opts[n_lopt] = kCuJitErrorLogBuffer;
+  link_optvals[n_lopt++] = err_log.data();
+  link_opts[n_lopt] = kCuJitErrorLogBufferSizeBytes;
+  link_optvals[n_lopt++] = (void *)err_sz;
+
+  void *link = nullptr;
+  QD_ERROR_IF(drv.link_create.call(n_lopt, link_opts, link_optvals, &link), "cuLinkCreate (culink-pertask) failed");
+  for (int i = 0; i < (int)cubins.size(); i++) {
+    auto name = fmt::format("construct_{}", i);
+    auto e = drv.link_add_data.call(link, kCuJitInputCubin, (void *)cubins[i].data(), cubins[i].size(), name.c_str(),
+                                    0, nullptr, nullptr);
+    if (e != 0)
+      QD_ERROR("cuLinkAddData construct {} failed err={} log=[{}]", i, e, err_log.data());
+  }
+  void *cubin = nullptr;
+  std::size_t cubin_sz = 0;
+  auto e_cmp = drv.link_complete.call(link, &cubin, &cubin_sz);
+  if (e_cmp != 0)
+    QD_ERROR("cuLinkComplete (culink-pertask) failed err={} log=[{}]", e_cmp, err_log.data());
+  void *cuda_module = nullptr;
+  QD_ERROR_IF(drv.module_load_data.call(&cuda_module, cubin), "module_load_data (culink-pertask) failed");
+  drv.link_destroy.call(link);
+
+  this->modules.push_back(std::make_unique<JITModuleCUDA>(cuda_module));
+  return this->modules.back().get();
 }
 
 llvm::DataLayout JITSessionCUDA::get_data_layout() {

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -213,9 +213,9 @@ static std::vector<char> ptx_to_relocatable_cubin(const std::string &ptx, const 
 // LLVM->PTX stays serialised: per-task modules may share an LLVMContext, unsafe for concurrent codegen.
 static std::mutex g_ptxgen_mu;
 
-// Per-task relocatable-cubin disk cache: a warm unchanged task skips PTX + ptxas. Dir <offline_cache>/culink_cubins_<mcpu>,
-// namespaced by SM since ptxas output isn't portable. Keyed on the module's LLVM-IR text (it carries the entry-point
-// symbol names, so distinct kernels can't collide). offline_cache=False -> mem-only build, no disk touched.
+// Per-task relocatable-cubin disk cache under <offline_cache>/culink_cubins_<mcpu> (namespaced by SM, since ptxas
+// output isn't portable). A warm unchanged task skips PTX + ptxas. Keyed on the module's LLVM-IR text, which carries
+// the entry-point symbol names, so distinct kernels can't collide. offline_cache=False -> mem-only, no disk touched.
 std::vector<char> JITSessionCUDA::get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module) {
   namespace fs = std::filesystem;
   const std::string mcpu = CUDAContext::get_instance().get_mcpu();
@@ -269,9 +269,8 @@ std::vector<char> JITSessionCUDA::assemble_and_store_cubin(const std::string &pt
   auto cubin = ptx_to_relocatable_cubin(ptx, CUDAContext::get_instance().get_mcpu());
   // temp + rename so a concurrent reader never sees a partial cubin
   std::error_code ec;
-  auto tmp = cubin_path + fmt::format(".tmp{}", (unsigned long long)std::chrono::steady_clock::now()
-                                                    .time_since_epoch()
-                                                    .count());
+  auto tmp = cubin_path +
+             fmt::format(".tmp{}", (unsigned long long)std::chrono::steady_clock::now().time_since_epoch().count());
   {
     std::ofstream o(tmp, std::ios::binary);
     o.write(cubin.data(), (std::streamsize)cubin.size());
@@ -316,8 +315,8 @@ JITModule *JITSessionCUDA::add_module_culink(std::vector<PerConstructArtifact> a
   QD_ERROR_IF(drv.link_create.call(n_lopt, link_opts, link_optvals, &link), "cuLinkCreate (culink-pertask) failed");
   for (int i = 0; i < (int)cubins.size(); i++) {
     auto name = fmt::format("construct_{}", i);
-    auto e = drv.link_add_data.call(link, kCuJitInputCubin, (void *)cubins[i].data(), cubins[i].size(), name.c_str(),
-                                    0, nullptr, nullptr);
+    auto e = drv.link_add_data.call(link, kCuJitInputCubin, (void *)cubins[i].data(), cubins[i].size(), name.c_str(), 0,
+                                    nullptr, nullptr);
     if (e != 0)
       QD_ERROR("cuLinkAddData construct {} failed err={} log=[{}]", i, e, err_log.data());
   }

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -183,9 +183,7 @@ JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_r
   return modules.back().get();
 }
 
-// Emit a *relocatable* cubin from PTX via `ptxas -c` (shell-out; production would link libnvptxcompiler_static).
-// Relocatable is mandatory: an executable cubin cannot be re-linked by cuLink, which rejects it with err 209.
-// Temp files under the system temp dir, cleaned up.
+// PTX -> *relocatable* cubin via `ptxas -c`. Relocatable is mandatory: cuLink rejects an executable cubin (err 209).
 static std::vector<char> ptx_to_relocatable_cubin(const std::string &ptx, const std::string &arch) {
   namespace fs = std::filesystem;
   static std::atomic<uint64_t> ctr{0};
@@ -194,8 +192,7 @@ static std::vector<char> ptx_to_relocatable_cubin(const std::string &ptx, const 
   auto ptx_path = fs::temp_directory_path() / (stem + ".ptx");
   auto cubin_path = fs::temp_directory_path() / (stem + ".cubin");
   {
-    // compile_module_to_ptx NUL-terminates the buffer so the driver's cuModuleLoadDataEx gets a C-string image.
-    // ptxas (CUDA 13+) treats an embedded NUL as a premature EOF and aborts, so write only up to the terminator.
+    // ptxas (CUDA 13+) reads the trailing NUL compile_module_to_ptx adds (for the driver) as premature EOF; trim it.
     std::streamsize ptx_len = (std::streamsize)ptx.size();
     while (ptx_len > 0 && ptx[ptx_len - 1] == '\0')
       --ptx_len;
@@ -213,26 +210,12 @@ static std::vector<char> ptx_to_relocatable_cubin(const std::string &ptx, const 
   return bytes;
 }
 
-// LLVM->PTX stays serialised: the per-task modules are produced on the codegen worker threads and may share an
-// LLVMContext, which is not safe for concurrent codegen.
+// LLVM->PTX stays serialised: per-task modules may share an LLVMContext, unsafe for concurrent codegen.
 static std::mutex g_ptxgen_mu;
 
-// Per-task relocatable-cubin disk cache. A warm run with an unchanged task hits the cache and skips PTX + ptxas
-// entirely. Directory is <offline_cache>/culink_cubins_sm_<cc>, or /tmp/qd_culink_cubins_sm_<cc> when the offline
-// cache path is unset.
-//
-// `offline_cache=False` emulates a cold process, so -- exactly like `PtxCache` and the kernel-data cache -- this
-// falls back to a mem-only build that touches no disk: nothing is read, nothing is written, not even the directory
-// is created. Otherwise a fresh session run with `offline_cache=False` would be served a cubin left by a previous
-// run and would not see the true cold start the flag promises.
-//
-// The key is a hash of the module's LLVM-IR text, which is what makes the cache safe to share across kernels: the
-// text contains the task's entry-point symbol names, so two kernels whose tasks differ only in name cannot collide
-// on one cubin.
-//
-// Cubins are SM-specific (`ptxas -arch=`), so the directory is namespaced by mcpu -- otherwise a cache populated on
-// one GPU would be silently loaded on another. `fast_math` is folded into the key by `make_cache_key`; the rest of
-// the compile config is already folded into the LLVM IR upstream.
+// Per-task relocatable-cubin disk cache: a warm unchanged task skips PTX + ptxas. Dir <offline_cache>/culink_cubins_<mcpu>,
+// namespaced by SM since ptxas output isn't portable. Keyed on the module's LLVM-IR text (it carries the entry-point
+// symbol names, so distinct kernels can't collide). offline_cache=False -> mem-only build, no disk touched.
 std::vector<char> JITSessionCUDA::get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module) {
   namespace fs = std::filesystem;
   const std::string mcpu = CUDAContext::get_instance().get_mcpu();
@@ -256,10 +239,7 @@ std::vector<char> JITSessionCUDA::get_or_build_construct_cubin(std::unique_ptr<l
     const std::string key = ptx_cache_->make_cache_key(llvm_ir_str, config_.fast_math);
     cubin_path = (fs::path(dir) / (key + ".cubin")).string();
 
-    // The whole-module loader dumps each module's PTX under `debug_dump_path`; this path replaces it for every CUDA
-    // kernel, so it has to dump too or `QD_DUMP_IR=1` silently stops producing PTX. A cached cubin skips PTX
-    // generation altogether, so when dumps are requested bypass the read -- an explicit debug flag should give a
-    // complete set of artifacts rather than whatever survived from an earlier run.
+    // A cached cubin skips PTX, so bypass the read under QD_DUMP_IR (this path owns the per-kernel PTX dump).
     if (!dump_ir && fs::exists(cubin_path)) {
       std::ifstream in(cubin_path, std::ios::binary);
       return std::vector<char>((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
@@ -281,14 +261,13 @@ std::vector<char> JITSessionCUDA::get_or_build_construct_cubin(std::unique_ptr<l
   }
   if (on_disk)
     return assemble_and_store_cubin(ptx, cubin_path);
-  // Mem-only (offline_cache=False): assemble the relocatable cubin without persisting it.
-  return ptx_to_relocatable_cubin(ptx, mcpu);
+  return ptx_to_relocatable_cubin(ptx, mcpu);  // mem-only: assemble without persisting
 }
 
 std::vector<char> JITSessionCUDA::assemble_and_store_cubin(const std::string &ptx, const std::string &cubin_path) {
   namespace fs = std::filesystem;
   auto cubin = ptx_to_relocatable_cubin(ptx, CUDAContext::get_instance().get_mcpu());
-  // atomic-ish write via temp + rename so concurrent builders don't read a partial cubin
+  // temp + rename so a concurrent reader never sees a partial cubin
   std::error_code ec;
   auto tmp = cubin_path + fmt::format(".tmp{}", (unsigned long long)std::chrono::steady_clock::now()
                                                     .time_since_epoch()
@@ -304,8 +283,7 @@ std::vector<char> JITSessionCUDA::assemble_and_store_cubin(const std::string &pt
 }
 
 JITModule *JITSessionCUDA::add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg) {
-  // Emit a cached relocatable cubin per task (`ptxas -c`) and device-link them into one CUmodule, so an unchanged
-  // task skips PTX + ptxas entirely.
+  // A cached relocatable cubin per task, device-linked into one CUmodule.
   constexpr uint32 kCuJitInputCubin = 0;
   constexpr uint32 kCuJitErrorLogBuffer = 5;
   constexpr uint32 kCuJitErrorLogBufferSizeBytes = 6;

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -110,7 +110,7 @@ JITSessionCUDA::JITSessionCUDA(QuadrantsLLVMContext *tlctx,
   program_impl_->register_needs_finalizing(finalizer_.get());
 }
 
-JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_reg) {
+std::string JITSessionCUDA::compile_module_to_ptx_with_dump(std::unique_ptr<llvm::Module> &module) {
   // Read through get_environ_config, as codegen_llvm.cpp does for QD_DUMP_IR and QD_LOAD_IR, so that a value of 0
   // turns the variable off here too rather than only its absence.
   const bool dump_ir = get_environ_config(DUMP_IR_ENV.data()) != 0;
@@ -119,7 +119,7 @@ JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_r
   // Capture the dump name before compile_module_to_ptx renames functions via convert().
   std::string dump_name;
   if (dump_ir || load_ptx_from_dump) {
-    dump_name = moduleToDumpName(M.get());
+    dump_name = moduleToDumpName(module.get());
   }
 
   if (dump_ir && !dump_name.empty()) {
@@ -129,14 +129,14 @@ JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_r
     std::error_code EC;
     llvm::raw_fd_ostream dest_file(filename.string(), EC);
     if (!EC) {
-      M->print(dest_file, nullptr);
+      module->print(dest_file, nullptr);
     } else {
       std::cout << "problem dumping file " << filename.string() << ": " << EC.message() << std::endl;
       QD_ERROR("Failed to dump LLVM IR to file: {}", filename.string());
     }
   }
 
-  auto ptx = compile_module_to_ptx(M);
+  auto ptx = compile_module_to_ptx(module);
   if (this->config_.print_kernel_asm) {
     static FileSequenceWriter writer("quadrants_kernel_nvptx_{:04d}.ptx", "module NVPTX");
     writer.write(ptx);
@@ -171,6 +171,11 @@ JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_r
       QD_WARN("Failed to open PTX file for loading: {}", ptx_path.string());
     }
   }
+  return ptx;
+}
+
+JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_reg) {
+  auto ptx = compile_module_to_ptx_with_dump(M);
 
   // TODO: figure out why using the guard leads to wrong tests results
   // auto context_guard = CUDAContext::get_instance().get_guard();
@@ -215,10 +220,11 @@ JITModule *JITSessionCUDA::add_module_per_task(std::vector<PerConstructArtifact>
   auto &drv = CUDADriver::get_instance();
 
   // The cheap LLVM->PTX step (the expensive PTX->SASS now happens in the driver at load, cached in ~/.nv/ComputeCache).
+  // Use the dump-aware variant so QD_DUMP_IR / QD_LOAD_IR behave the same per task as on the whole-module path.
   std::vector<std::string> ptxs(artifacts.size());
   for (std::size_t i = 0; i < artifacts.size(); i++) {
     std::lock_guard<std::mutex> g(g_ptxgen_mu);
-    ptxs[i] = compile_module_to_ptx(artifacts[i].module);
+    ptxs[i] = compile_module_to_ptx_with_dump(artifacts[i].module);
   }
 
   CUDAContext::get_instance().make_current();

--- a/quadrants/runtime/cuda/jit_cuda.cpp
+++ b/quadrants/runtime/cuda/jit_cuda.cpp
@@ -1,6 +1,4 @@
-#include <atomic>
 #include <chrono>
-#include <iterator>
 #include <mutex>
 #include <random>
 #include <vector>
@@ -36,22 +34,44 @@ std::string moduleToDumpName(llvm::Module *const M) {
   return M->getName().str();
 }
 
-JITModuleCUDA::JITModuleCUDA(void *module) : module_(module) {
+JITModuleCUDA::JITModuleCUDA(void *module) : modules_{module} {
+}
+
+JITModuleCUDA::JITModuleCUDA(std::vector<void *> modules) : modules_(std::move(modules)) {
 }
 
 void *JITModuleCUDA::lookup_function(const std::string &name) {
   // TODO: figure out why using the guard leads to wrong tests results
   // auto context_guard = CUDAContext::get_instance().get_guard();
   CUDAContext::get_instance().make_current();
+  {
+    std::lock_guard<std::mutex> g(func_mu_);
+    auto it = func_cache_.find(name);
+    if (it != func_cache_.end()) {
+      return it->second;
+    }
+  }
   void *func = nullptr;
   auto t = Time::get_time();
-  auto err = CUDADriver::get_instance().module_get_function.call_with_warning(&func, module_, name.c_str());
-  if (err) {
+  auto &drv = CUDADriver::get_instance();
+  // The symbol lives in exactly one module. Use the non-warning `call` so probing the other modules (which return
+  // CUDA_ERROR_NOT_FOUND) does not spam the log; only a miss across *all* modules is an error.
+  for (void *m : modules_) {
+    void *f = nullptr;
+    if (drv.module_get_function.call(&f, m, name.c_str()) == 0 && f != nullptr) {
+      func = f;
+      break;
+    }
+  }
+  if (func == nullptr) {
     QD_ERROR("Cannot look up function {}", name);
   }
   t = Time::get_time() - t;
   QD_TRACE("CUDA module_get_function {} costs {} ms", name, t * 1000);
-  QD_ASSERT(func != nullptr);
+  {
+    std::lock_guard<std::mutex> g(func_mu_);
+    func_cache_[name] = func;
+  }
   return func;
 }
 
@@ -183,153 +203,37 @@ JITModule *JITSessionCUDA::add_module(std::unique_ptr<llvm::Module> M, int max_r
   return modules.back().get();
 }
 
-// PTX -> *relocatable* cubin via `ptxas -c`. Relocatable is mandatory: cuLink rejects an executable cubin (err 209).
-static std::vector<char> ptx_to_relocatable_cubin(const std::string &ptx, const std::string &arch) {
-  namespace fs = std::filesystem;
-  static std::atomic<uint64_t> ctr{0};
-  auto now = std::chrono::steady_clock::now().time_since_epoch().count();
-  auto stem = fmt::format("qd_culink_{}_{}", (unsigned long long)now, ctr.fetch_add(1));
-  auto ptx_path = fs::temp_directory_path() / (stem + ".ptx");
-  auto cubin_path = fs::temp_directory_path() / (stem + ".cubin");
-  {
-    // ptxas (CUDA 13+) reads the trailing NUL compile_module_to_ptx adds (for the driver) as premature EOF; trim it.
-    std::streamsize ptx_len = (std::streamsize)ptx.size();
-    while (ptx_len > 0 && ptx[ptx_len - 1] == '\0')
-      --ptx_len;
-    std::ofstream o(ptx_path, std::ios::binary);
-    o.write(ptx.data(), ptx_len);
-  }
-  auto cmd = fmt::format("ptxas -c -arch={} {} -o {} 2>/dev/null", arch, ptx_path.string(), cubin_path.string());
-  int rc = std::system(cmd.c_str());
-  QD_ERROR_IF(rc != 0, "ptxas -c failed (rc={}) arch={}", rc, arch);
-  std::ifstream in(cubin_path, std::ios::binary);
-  std::vector<char> bytes((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-  std::error_code ec;
-  fs::remove(ptx_path, ec);
-  fs::remove(cubin_path, ec);
-  return bytes;
-}
-
 // LLVM->PTX stays serialised: per-task modules may share an LLVMContext, unsafe for concurrent codegen.
 static std::mutex g_ptxgen_mu;
 
-// Per-task relocatable-cubin disk cache under <offline_cache>/culink_cubins_<mcpu> (namespaced by SM, since ptxas
-// output isn't portable). A warm unchanged task skips PTX + ptxas. Keyed on the module's LLVM-IR text, which carries
-// the entry-point symbol names, so distinct kernels can't collide. offline_cache=False -> mem-only, no disk touched.
-std::vector<char> JITSessionCUDA::get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module) {
-  namespace fs = std::filesystem;
-  const std::string mcpu = CUDAContext::get_instance().get_mcpu();
-  std::error_code ec;
-
-  // Captured before compile_module_to_ptx, which renames functions via convert().
-  const bool dump_ir = get_environ_config(DUMP_IR_ENV.data()) != 0;
-
-  const bool on_disk = config_.offline_cache;
-  std::string cubin_path;
-  if (on_disk) {
-    const std::string leaf = "culink_cubins_" + mcpu;
-    const std::string dir =
-        config_.offline_cache_file_path.empty() ? ("/tmp/qd_" + leaf) : (config_.offline_cache_file_path + "/" + leaf);
-    fs::create_directories(dir, ec);
-
-    std::string llvm_ir_str;
-    llvm::raw_string_ostream os(llvm_ir_str);
-    module->print(os, nullptr);
-    os.flush();
-    const std::string key = ptx_cache_->make_cache_key(llvm_ir_str, config_.fast_math);
-    cubin_path = (fs::path(dir) / (key + ".cubin")).string();
-
-    // A cached cubin skips PTX, so bypass the read under QD_DUMP_IR (this path owns the per-kernel PTX dump).
-    if (!dump_ir && fs::exists(cubin_path)) {
-      std::ifstream in(cubin_path, std::ios::binary);
-      return std::vector<char>((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
-    }
-  }
-
-  const std::string dump_name = dump_ir ? moduleToDumpName(module.get()) : std::string();
-  std::string ptx;
-  {
-    std::lock_guard<std::mutex> g(g_ptxgen_mu);
-    ptx = compile_module_to_ptx(module);
-  }
-  if (dump_ir && !dump_name.empty()) {
-    fs::path ir_dump_dir = config_.debug_dump_path;
-    fs::create_directories(ir_dump_dir, ec);
-    if (std::ofstream out(ir_dump_dir / (dump_name + ".ptx")); out.is_open()) {
-      out << ptx << std::endl;
-    }
-  }
-  if (on_disk)
-    return assemble_and_store_cubin(ptx, cubin_path);
-  return ptx_to_relocatable_cubin(ptx, mcpu);  // mem-only: assemble without persisting
-}
-
-std::vector<char> JITSessionCUDA::assemble_and_store_cubin(const std::string &ptx, const std::string &cubin_path) {
-  namespace fs = std::filesystem;
-  auto cubin = ptx_to_relocatable_cubin(ptx, CUDAContext::get_instance().get_mcpu());
-  // temp + rename so a concurrent reader never sees a partial cubin
-  std::error_code ec;
-  auto tmp = cubin_path +
-             fmt::format(".tmp{}", (unsigned long long)std::chrono::steady_clock::now().time_since_epoch().count());
-  {
-    std::ofstream o(tmp, std::ios::binary);
-    o.write(cubin.data(), (std::streamsize)cubin.size());
-  }
-  fs::rename(tmp, cubin_path, ec);
-  if (ec)
-    fs::remove(tmp, ec);
-  return cubin;
-}
-
-JITModule *JITSessionCUDA::add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg) {
-  // A cached relocatable cubin per task, device-linked into one CUmodule.
-  constexpr uint32 kCuJitInputCubin = 0;
-  constexpr uint32 kCuJitErrorLogBuffer = 5;
-  constexpr uint32 kCuJitErrorLogBufferSizeBytes = 6;
+JITModule *JITSessionCUDA::add_module_per_task(std::vector<PerConstructArtifact> artifacts, int max_reg) {
+  // Per-task path (toolkit-free): compile each self-contained task module to PTX and load it as its OWN CUmodule via
+  // the driver (cuModuleLoadDataEx); the composite JITModuleCUDA below resolves tasks by name across the N modules.
+  // No `ptxas`, no relocatable cubins, no `cuLink`, so this runs on a driver-only machine. Per-task reuse rides on
+  // `PtxCache` (PTX, keyed on LLVM text, consulted inside compile_module_to_ptx) plus the driver compute cache (SASS).
+  (void)max_reg;  // No link step here (per-task whole-module driver load), so there is nowhere to apply max-reg.
   auto &drv = CUDADriver::get_instance();
 
-  std::vector<std::vector<char>> cubins;
-  cubins.reserve(artifacts.size());
-  for (auto &art : artifacts) {
-    cubins.push_back(get_or_build_construct_cubin(art.module));
+  // The cheap LLVM->PTX step (the expensive PTX->SASS now happens in the driver at load, cached in ~/.nv/ComputeCache).
+  std::vector<std::string> ptxs(artifacts.size());
+  for (std::size_t i = 0; i < artifacts.size(); i++) {
+    std::lock_guard<std::mutex> g(g_ptxgen_mu);
+    ptxs[i] = compile_module_to_ptx(artifacts[i].module);
   }
 
   CUDAContext::get_instance().make_current();
   [[maybe_unused]] auto _ = CUDAContext::get_instance().get_lock_guard();
 
-  std::vector<char> err_log(8192, 0);
-  std::size_t err_sz = err_log.size();
-  uint32 link_opts[3];
-  void *link_optvals[3];
-  int n_lopt = 0;
-  if (max_reg != 0) {
-    link_opts[n_lopt] = CU_JIT_MAX_REGISTERS;
-    link_optvals[n_lopt++] = &max_reg;
+  std::vector<void *> mods;
+  mods.reserve(ptxs.size());
+  for (auto &ptx : ptxs) {
+    void *cuda_module = nullptr;
+    // c_str() hands over the NUL-terminated image cuModuleLoadDataEx wants, exactly like the whole-module path.
+    QD_ERROR_IF(drv.module_load_data_ex.call(&cuda_module, ptx.c_str(), 0, nullptr, nullptr),
+                "module_load_data_ex (per-task) failed");
+    mods.push_back(cuda_module);
   }
-  link_opts[n_lopt] = kCuJitErrorLogBuffer;
-  link_optvals[n_lopt++] = err_log.data();
-  link_opts[n_lopt] = kCuJitErrorLogBufferSizeBytes;
-  link_optvals[n_lopt++] = (void *)err_sz;
-
-  void *link = nullptr;
-  QD_ERROR_IF(drv.link_create.call(n_lopt, link_opts, link_optvals, &link), "cuLinkCreate (culink-pertask) failed");
-  for (int i = 0; i < (int)cubins.size(); i++) {
-    auto name = fmt::format("construct_{}", i);
-    auto e = drv.link_add_data.call(link, kCuJitInputCubin, (void *)cubins[i].data(), cubins[i].size(), name.c_str(), 0,
-                                    nullptr, nullptr);
-    if (e != 0)
-      QD_ERROR("cuLinkAddData construct {} failed err={} log=[{}]", i, e, err_log.data());
-  }
-  void *cubin = nullptr;
-  std::size_t cubin_sz = 0;
-  auto e_cmp = drv.link_complete.call(link, &cubin, &cubin_sz);
-  if (e_cmp != 0)
-    QD_ERROR("cuLinkComplete (culink-pertask) failed err={} log=[{}]", e_cmp, err_log.data());
-  void *cuda_module = nullptr;
-  QD_ERROR_IF(drv.module_load_data.call(&cuda_module, cubin), "module_load_data (culink-pertask) failed");
-  drv.link_destroy.call(link);
-
-  this->modules.push_back(std::make_unique<JITModuleCUDA>(cuda_module));
+  this->modules.push_back(std::make_unique<JITModuleCUDA>(std::move(mods)));
   return this->modules.back().get();
 }
 

--- a/quadrants/runtime/cuda/jit_cuda.h
+++ b/quadrants/runtime/cuda/jit_cuda.h
@@ -66,11 +66,8 @@ class JITSessionCUDA : public JITSession {
                  ProgramImpl *program_impl);
   JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg) override;
   JITModule *add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg) override;
-  // Return a relocatable cubin for one self-contained task module, hitting a disk cache (skips PTX + ptxas on a warm
-  // unchanged task). Keyed on the module's LLVM-IR text (which carries the entry-point symbol names).
+  // Relocatable cubin for one task module, via a disk cache keyed on the module's LLVM-IR text.
   std::vector<char> get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module);
-  // `ptxas -c` + atomic write of the result. Split out from the above because it holds no shared state, so it is
-  // safe to call concurrently.
   std::vector<char> assemble_and_store_cubin(const std::string &ptx, const std::string &cubin_path);
   llvm::DataLayout get_data_layout() override;
 

--- a/quadrants/runtime/cuda/jit_cuda.h
+++ b/quadrants/runtime/cuda/jit_cuda.h
@@ -1,4 +1,7 @@
 #include <memory>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
 
 #include "llvm/ADT/StringRef.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -39,10 +42,16 @@ namespace quadrants::lang {
 #if defined(QD_WITH_CUDA)
 class JITModuleCUDA : public JITModule {
  private:
-  void *module_;
+  // A kernel is either one whole-module CUmodule or N self-contained per-task CUmodules (per-task path). A task's
+  // entry symbol lives in exactly one of them; `func_cache_` memoises the resolved CUfunction so the launcher / graph
+  // builder does not rescan the N modules on every by-name lookup.
+  std::vector<void *> modules_;
+  std::unordered_map<std::string, void *> func_cache_;
+  std::mutex func_mu_;
 
  public:
   explicit JITModuleCUDA(void *module);
+  explicit JITModuleCUDA(std::vector<void *> modules);
   void *lookup_function(const std::string &name) override;
   void call(const std::string &name,
             const std::vector<void *> &arg_pointers,
@@ -65,10 +74,7 @@ class JITSessionCUDA : public JITSession {
                  llvm::DataLayout data_layout,
                  ProgramImpl *program_impl);
   JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg) override;
-  JITModule *add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg) override;
-  // Relocatable cubin for one task module, via a disk cache keyed on the module's LLVM-IR text.
-  std::vector<char> get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module);
-  std::vector<char> assemble_and_store_cubin(const std::string &ptx, const std::string &cubin_path);
+  JITModule *add_module_per_task(std::vector<PerConstructArtifact> artifacts, int max_reg) override;
   llvm::DataLayout get_data_layout() override;
 
  private:

--- a/quadrants/runtime/cuda/jit_cuda.h
+++ b/quadrants/runtime/cuda/jit_cuda.h
@@ -92,6 +92,10 @@ class JITSessionCUDA : public JITSession {
   };
 
   std::string compile_module_to_ptx(std::unique_ptr<llvm::Module> &module);
+  // compile_module_to_ptx plus the QD_DUMP_IR / QD_LOAD_IR side effects (dump <name>_before_ptx.ll and <name>.ptx
+  // under debug_dump_path, optionally reload PTX from that dump). Shared by the whole-module and per-task load paths
+  // so their debug-dump behaviour stays identical. Callers sharing an LLVMContext across modules must serialise it.
+  std::string compile_module_to_ptx_with_dump(std::unique_ptr<llvm::Module> &module);
   std::unique_ptr<PtxCache> ptx_cache_;
   ProgramImpl *program_impl_;
   std::unique_ptr<Finalizer> finalizer_;

--- a/quadrants/runtime/cuda/jit_cuda.h
+++ b/quadrants/runtime/cuda/jit_cuda.h
@@ -65,6 +65,13 @@ class JITSessionCUDA : public JITSession {
                  llvm::DataLayout data_layout,
                  ProgramImpl *program_impl);
   JITModule *add_module(std::unique_ptr<llvm::Module> M, int max_reg) override;
+  JITModule *add_module_culink(std::vector<PerConstructArtifact> artifacts, int max_reg) override;
+  // Return a relocatable cubin for one self-contained task module, hitting a disk cache (skips PTX + ptxas on a warm
+  // unchanged task). Keyed on the module's LLVM-IR text (which carries the entry-point symbol names).
+  std::vector<char> get_or_build_construct_cubin(std::unique_ptr<llvm::Module> &module);
+  // `ptxas -c` + atomic write of the result. Split out from the above because it holds no shared state, so it is
+  // safe to call concurrently.
+  std::vector<char> assemble_and_store_cubin(const std::string &ptx, const std::string &cubin_path);
   llvm::DataLayout get_data_layout() override;
 
  private:

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -605,8 +605,7 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(const LLVM::Compiled
     auto data = compiled.get_internal_data().compiled_data.clone();
     JITModule *jit_module = nullptr;
     if (!data.per_construct_artifacts.empty()) {
-      // Per-task cubin path: assemble the module from self-contained per-task artifacts via cuLink, instead of
-      // loading the whole-module PTX.
+      // Per-task cubin path: cuLink the per-task modules instead of loading the whole-module PTX.
       jit_module = executor->create_jit_module_culink(std::move(data.per_construct_artifacts));
     } else {
       jit_module = executor->create_jit_module(std::move(data.module));

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -605,8 +605,8 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(const LLVM::Compiled
     auto data = compiled.get_internal_data().compiled_data.clone();
     JITModule *jit_module = nullptr;
     if (!data.per_construct_artifacts.empty()) {
-      // Per-task cubin path: cuLink the per-task modules instead of loading the whole-module PTX.
-      jit_module = executor->create_jit_module_culink(std::move(data.per_construct_artifacts));
+      // Per-task path: load each per-task module separately (composite JITModule) instead of the whole-module PTX.
+      jit_module = executor->create_jit_module_per_task(std::move(data.per_construct_artifacts));
     } else {
       jit_module = executor->create_jit_module(std::move(data.module));
     }

--- a/quadrants/runtime/cuda/kernel_launcher.cpp
+++ b/quadrants/runtime/cuda/kernel_launcher.cpp
@@ -603,7 +603,14 @@ KernelLauncher::Handle KernelLauncher::register_llvm_kernel(const LLVM::Compiled
     auto *executor = get_runtime_executor();
 
     auto data = compiled.get_internal_data().compiled_data.clone();
-    auto *jit_module = executor->create_jit_module(std::move(data.module));
+    JITModule *jit_module = nullptr;
+    if (!data.per_construct_artifacts.empty()) {
+      // Per-task cubin path: assemble the module from self-contained per-task artifacts via cuLink, instead of
+      // loading the whole-module PTX.
+      jit_module = executor->create_jit_module_culink(std::move(data.per_construct_artifacts));
+    } else {
+      jit_module = executor->create_jit_module(std::move(data.module));
+    }
 
     // Populate ctx
     ctx.jit_module = jit_module;

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -176,6 +176,10 @@ JITModule *LlvmRuntimeExecutor::create_jit_module(std::unique_ptr<llvm::Module> 
   return jit_session_->add_module(std::move(module));
 }
 
+JITModule *LlvmRuntimeExecutor::create_jit_module_culink(std::vector<PerConstructArtifact> artifacts) {
+  return jit_session_->add_module_culink(std::move(artifacts));
+}
+
 JITModule *LlvmRuntimeExecutor::get_runtime_jit_module() {
   return runtime_jit_module_;
 }

--- a/quadrants/runtime/llvm/llvm_runtime_executor.cpp
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.cpp
@@ -176,8 +176,8 @@ JITModule *LlvmRuntimeExecutor::create_jit_module(std::unique_ptr<llvm::Module> 
   return jit_session_->add_module(std::move(module));
 }
 
-JITModule *LlvmRuntimeExecutor::create_jit_module_culink(std::vector<PerConstructArtifact> artifacts) {
-  return jit_session_->add_module_culink(std::move(artifacts));
+JITModule *LlvmRuntimeExecutor::create_jit_module_per_task(std::vector<PerConstructArtifact> artifacts) {
+  return jit_session_->add_module_per_task(std::move(artifacts));
 }
 
 JITModule *LlvmRuntimeExecutor::get_runtime_jit_module() {

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -72,6 +72,9 @@ class LlvmRuntimeExecutor {
   QuadrantsLLVMContext *get_llvm_context();
 
   JITModule *create_jit_module(std::unique_ptr<llvm::Module> module);
+  // Per-task cuLink path: each artifact is one offloaded task (module-to-compile or cached cubin) plus its launch
+  // metadata.
+  JITModule *create_jit_module_culink(std::vector<PerConstructArtifact> artifacts);
 
   JITModule *get_runtime_jit_module();
 

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -72,8 +72,8 @@ class LlvmRuntimeExecutor {
   QuadrantsLLVMContext *get_llvm_context();
 
   JITModule *create_jit_module(std::unique_ptr<llvm::Module> module);
-  // Per-task cuLink path: one module per artifact.
-  JITModule *create_jit_module_culink(std::vector<PerConstructArtifact> artifacts);
+  // Per-task path: one loadable module per artifact, behind a composite JITModule.
+  JITModule *create_jit_module_per_task(std::vector<PerConstructArtifact> artifacts);
 
   JITModule *get_runtime_jit_module();
 

--- a/quadrants/runtime/llvm/llvm_runtime_executor.h
+++ b/quadrants/runtime/llvm/llvm_runtime_executor.h
@@ -72,8 +72,7 @@ class LlvmRuntimeExecutor {
   QuadrantsLLVMContext *get_llvm_context();
 
   JITModule *create_jit_module(std::unique_ptr<llvm::Module> module);
-  // Per-task cuLink path: each artifact is one offloaded task (module-to-compile or cached cubin) plus its launch
-  // metadata.
+  // Per-task cuLink path: one module per artifact.
   JITModule *create_jit_module_culink(std::vector<PerConstructArtifact> artifacts);
 
   JITModule *get_runtime_jit_module();

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -469,8 +469,8 @@ def test_atomic_float_ops(op, dtype):
         "min": 0.0,
         "max": (block_dim - 1) * SCALE,
     }
-    # f16 add/sub of 128 concurrent atomics is order-dependent (~1e-2 across interleavings); cuLink changes the order.
-    # A real failure (dropped block) would be off by 75, far outside 1e-2.
+    # f16 add/sub of 128 concurrent atomics is order-dependent (~1e-2 across interleavings); the per-task module path
+    # changes the order. A real failure (dropped block) would be off by 75, far outside 1e-2.
     rtol = {qd.f16: 1e-2, qd.f64: 1e-10}.get(dtype, 1e-6)
     assert arr[0] == test_utils.approx(expected[op], rel=rtol)
 

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -469,11 +469,8 @@ def test_atomic_float_ops(op, dtype):
         "min": 0.0,
         "max": (block_dim - 1) * SCALE,
     }
-    # add/sub accumulate 128 concurrent atomics in whatever order the hardware interleaves them, and f16 has too few
-    # mantissa bits for that to be order-independent: past 256 the ULP is 0.25, so each of the last ~60 adds can round.
-    # Shuffling these same inputs spans 300.75..303.25 against a true 302.16, i.e. ~1e-2 relative. The old 1e-3 held
-    # only for as long as codegen happened to produce one particular interleaving. A real failure (a dropped block)
-    # would be off by 75, well outside this.
+    # f16 add/sub of 128 concurrent atomics is order-dependent (~1e-2 across interleavings); cuLink changes the order.
+    # A real failure (dropped block) would be off by 75, far outside 1e-2.
     rtol = {qd.f16: 1e-2, qd.f64: 1e-10}.get(dtype, 1e-6)
     assert arr[0] == test_utils.approx(expected[op], rel=rtol)
 

--- a/tests/python/test_atomic.py
+++ b/tests/python/test_atomic.py
@@ -469,7 +469,12 @@ def test_atomic_float_ops(op, dtype):
         "min": 0.0,
         "max": (block_dim - 1) * SCALE,
     }
-    rtol = {qd.f16: 1e-3, qd.f64: 1e-10}.get(dtype, 1e-6)
+    # add/sub accumulate 128 concurrent atomics in whatever order the hardware interleaves them, and f16 has too few
+    # mantissa bits for that to be order-independent: past 256 the ULP is 0.25, so each of the last ~60 adds can round.
+    # Shuffling these same inputs spans 300.75..303.25 against a true 302.16, i.e. ~1e-2 relative. The old 1e-3 held
+    # only for as long as codegen happened to produce one particular interleaving. A real failure (a dropped block)
+    # would be off by 75, well outside this.
+    rtol = {qd.f16: 1e-2, qd.f64: 1e-10}.get(dtype, 1e-6)
     assert arr[0] == test_utils.approx(expected[op], rel=rtol)
 
 


### PR DESCRIPTION
### Summary

Split CUDA kernel compilation per offloaded task, but keep it **toolkit-free**. Each offloaded task becomes its own self-contained module (`PerConstructArtifact{ module }`); at JIT time each is compiled to PTX and loaded as its own `CUmodule` via `cuModuleLoadDataEx`. `JITModuleCUDA` becomes a composite that holds the N modules and resolves task entry points by name across them (memoised). The launcher and CUDA-graph builder are unchanged -- they only ever look tasks up by name.

This is "Option B" of the per-task compile design: it deliberately avoids `ptxas`/`cuLink`/a relocatable-cubin cache, so the path needs no CUDA toolkit at runtime and adds nothing to the wheel. (An earlier revision of this branch used `ptxas -c` + `cuLink` + a disk cubin cache; that requires a PTX assembler, which driver-only wheels and the GPU CI runners do not have -- hence the previous push's `ptxas -c ... rc=32512` failures.)

### What per-task buys us

Per-task reuse rides on the pre-existing cache tiers, now at task granularity because each task is a separate module:
- `PtxCache` (PTX, keyed on LLVM-IR text) -- an unchanged task skips LLVM->PTX.
- the NVIDIA driver compute cache (`~/.nv/ComputeCache`, SASS, keyed on PTX hash) -- an unchanged task skips `ptxas` inside the driver.

No new on-disk cache is introduced here; the cross-process per-task artifact cache is ref 6. 1b is the enabler: it makes each task an independently-compiled, independently-loadable unit that 6 / 8 / 10 build on.

### Changes

- `runtime/cuda/jit_cuda.{h,cpp}`: composite `JITModuleCUDA` (`vector<CUmodule>` + name->CUfunction memo); `add_module_per_task` compiles each task module to PTX and driver-loads it; deletes the `ptxas`/`cuLink`/cubin-cache code.
- `jit/jit_session.h`, `runtime/llvm/llvm_runtime_executor.{h,cpp}`, `runtime/cuda/kernel_launcher.cpp`: rename `add_module_culink` / `create_jit_module_culink` -> `..._per_task`.
- `codegen/codegen.cpp`, `codegen/llvm/{codegen_llvm.cpp,llvm_compiled_data.h}`: build one self-contained module per task into `per_construct_artifacts` (`PerConstructArtifact` is `{ module }`; the full record moves to 6).
- `codegen/cuda/codegen_cuda.cpp`: emit static shared scratch and `bls_buffer` as internal definitions so each per-task module is self-contained.
- `tests/python/test_atomic.py`: widen f16 tolerance (per-task codegen changes atomic interleaving order).
- `docs/source/user_guide/init_options.md`: trim the offline-cache description.

### Testing

RTX PRO 6000 (sm_120), CUDA container, editable build:
- `test_atomic` -- 96 passed.
- `reduction graph struct_for offload_cross offline_cache` -- 82 passed (exercises BLS / shared-memory reductions, CUDA-graph capture across the composite module, multi-offload struct-for, and offline-cache reuse).
- `pre-commit run` on the changed files -- clean.
