### PR TITLE
[Lang] W1 Cache spec keys for None kernel arguments

### DIFF
--- a/python/quadrants/lang/_template_mapper_hotpath.py
+++ b/python/quadrants/lang/_template_mapper_hotpath.py
@@ -73,7 +73,11 @@ AnnotationType = Union[
 
 _ExprCxx = _qd_core.ExprCxx
 _composite_mutable_types = {list, dict, set}
-_primitive_types = {int, float, bool}
+# ``type(None)`` belongs here so ``None`` arguments are treated like other primitives and excluded from the
+# weakref-based spec-key cache tracker in ``TemplateMapper.lookup``: ``weakref.ref(None)`` raises ``TypeError``, and
+# ``None`` is an immortal singleton that never needs lifetime tracking. Without it, the spec-key cache entry for a
+# ``None`` argument is dropped and every such launch re-runs full spec-key extraction.
+_primitive_types = {int, float, bool, type(None)}
 
 
 # Per-instance ndarray-path cache, stored OFF-instance in a module-level ``id(arg) -> list[paths]`` dict and cleaned

--- a/tests/python/test_tensor_annotation.py
+++ b/tests/python/test_tensor_annotation.py
@@ -244,6 +244,42 @@ def test_tensor_slot_later_wrapper_uses_impl_identity_cache():
     assert len(copy._primal.mapper._mapping_cache) == cache_size
 
 
+@test_utils.test()
+def test_none_argument_populates_spec_key_cache():
+    """A ``None`` in a ``qd.Tensor`` slot must land in the template mapper's spec-key cache.
+
+    ``TemplateMapper.lookup`` skips ``weakref``-tracking any argument whose type is in ``_primitive_types``.
+    ``NoneType`` is in that set, so ``weakref.ref(None)`` - which raises ``TypeError`` - is never attempted and the
+    entry is stored. Were ``NoneType`` absent, the ``TypeError`` would drop the entry and every ``None`` launch would
+    re-run full spec-key extraction instead of hitting the cache.
+    """
+    n = 4
+    a = qd.ndarray(qd.f32, shape=(n,))
+    a.from_numpy(np.arange(n, dtype=np.float32))
+    b = qd.ndarray(qd.f32, shape=(n,))
+    b.from_numpy(np.full(n, 100.0, dtype=np.float32))
+    c = qd.ndarray(qd.f32, shape=(n,))
+
+    @qd.kernel
+    def k(a: qd.types.NDArray[qd.f32, 1], b: qd.Tensor, c: qd.types.NDArray[qd.f32, 1]):
+        for i in range(a.shape[0]):
+            if qd.static(b is not None):
+                c[i] = a[i] + b[i]
+            else:
+                c[i] = a[i]
+
+    # A single launch with the optional slot absent must leave a cache entry behind.
+    k(a, None, c)
+    np.testing.assert_array_equal(c.to_numpy(), np.arange(n, dtype=np.float32))
+    assert len(k._primal.mapper._mapping_cache) == 1
+
+    # The present branch still works and specializes separately; the absent-branch entry is retained.
+    k(a, b, c)
+    np.testing.assert_array_equal(c.to_numpy(), np.arange(n, dtype=np.float32) + 100.0)
+    assert len(k._primal.mapper.mapping) == 2
+    assert len(k._primal.mapper._mapping_cache) == 2
+
+
 # Vector / matrix element types: qd.Tensor must dispatch the compound-element tensors built by qd.Vector.tensor /
 # qd.Matrix.tensor on both backends.
 


### PR DESCRIPTION
## Summary

A kernel argument of `None` (an absent optional `qd.Tensor` / `qd.template()` slot) is ~21% slower per launch than it should be, because its template-mapper spec-key cache entry is never stored.

`TemplateMapper.lookup` weakref-tracks every argument whose type is not in `_primitive_types`, so it can evict the spec-key cache entry when the argument is garbage-collected. `weakref.ref(None)` raises `TypeError`, which was caught and downgraded to a `warn_once`, leaving the entry unstored - so every launch passing `None` re-ran full spec-key extraction instead of hitting the cache.

This adds `NoneType` to `_primitive_types`. `None` is an immortal singleton that never needs lifetime tracking, so excluding it from the weakref loop is both correct and removes the overhead.

## Measurements

CPU, 20000 iterations, microseconds per launch, optional `qd.Tensor` slot:

| variant | before | after |
| --- | --- | --- |
| `b=None` | 148.6 | 122.8 |
| `b=ndarray` (present) | 123.9 | 123.9 |
| no optional slot (control) | 122.2 | 122.2 |

The absent branch does strictly less work than the present branch yet was slower than the control; the gap closes from +20.8% to ~0.3%. Specialization counts and results are unchanged. The spec-key cache now populates for a `None` argument (0 -> 1 entries).

## Test plan

- [x] New `test_none_argument_populates_spec_key_cache` passes on x64 and cuda
- [x] Full CPU suite via the CI harness (`tests/run_tests.py -r 3`, x64, split by `needs_torch` exactly as `linux/4_test.sh`): this branch's unique failing set is **identical to unmodified `main`** and the `needs_torch` phase passes clean, so this PR introduces **no new failures**.

The only shared failures are three tests that cannot pass in the offline cluster container regardless of branch (they fail the same way on `main`), all unrelated to this change:
  - `test_committed_fatbin_layout` - the container's `cuobjdump` predates CUDA 13 and misreads the **committed** cubin's build toolkit as `0.2` instead of `13.0+`;
  - `test_pyi_stubs` - `python -m pyright` cannot fetch its Node runtime on an offline compute node;
  - `test_ipython.ipynb` - `io.UnsupportedOperation` from quadrants' stdout wrapping under nbmake's ipykernel capture.

(An earlier revision of this checklist reported raw `pytest` counts; those were inflated because that run omitted CI's `-r 3` flaky-rerun, so load-induced flakes and xdist worker-kill collateral surfaced as hard failures. Under the CI harness they do not.)

Context: first of two prerequisite fixes for optional (`None`) kernel arguments, motivated by #856.

Made with [Cursor](https://cursor.com)
