### PR TITLE
[Doc] Fix doc quality on fastcache.md

### DIFF
--- a/docs/source/user_guide/fastcache.md
+++ b/docs/source/user_guide/fastcache.md
@@ -122,7 +122,7 @@ Each compiled artifact is stored under a key derived from all of the following:
 - The **source code** of the kernel function or any `@qd.func` it calls.
 - The **argument types** (e.g. switching from `f32` to `f64`, or changing ndarray dimensionality).
 - The **compilation-relevant parts of the compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`).
-- The **device capabilities** of the target GPU (e.g. whether Vulkan/Metal expose 64-bit integers, atomics, or a given subgroup family), since codegen branches on them. This keeps an entry compiled for one device from being reused on another with different capabilities, for example when a cache directory is shared across machines.
+- The **device capabilities** of the target GPU (e.g. whether Vulkan/Metal expose 64-bit integers, atomics, or a given subgroup family), since the compiler generates different GPU code depending on them. This keeps an entry compiled for one device from being reused on another with different capabilities, for example when a cache directory is shared across machines.
 - **Template parameter values** (since they are baked into the compiled kernel).
 
 When any of these change, the resulting key is different, so a new compilation occurs and a new entry is stored. Previous entries remain on disk - multiple cached versions coexist. You do not need to manually clear the cache when making code changes - the hash mismatch causes a transparent recompilation.

--- a/docs/source/user_guide/fastcache.md
+++ b/docs/source/user_guide/fastcache.md
@@ -86,7 +86,7 @@ The same holds for a [`dataclasses.dataclass`](compound_types.md#dataclassesdata
 |---|---|
 | `enum.Enum` values (e.g. `MyEnum.VALUE`) | Named constants that are assumed not to vary between process runs. |
 | `math` / `numpy` constants (e.g. `math.pi`) | Assumed stable across process runs. |
-| Quadrants module attributes (e.g. `qd.simt.Tile16x16.SIZE`) | Part of the compiler's own API; assumed consistent with the Quadrants version hash. |
+| Quadrants module attributes (e.g. [`qd.simt.Tile16x16.SIZE`](tile.md)) | Part of the compiler's own API; assumed consistent with the Quadrants version hash. |
 
 Other named constants (non-enum, non-module) captured from scope will raise a `QuadrantsCompilationError`, except for `UPPERCASE` names which emit a warning instead.
 
@@ -122,7 +122,7 @@ Each compiled artifact is stored under a key derived from all of the following:
 - The **source code** of the kernel function or any `@qd.func` it calls.
 - The **argument types** (e.g. switching from `f32` to `f64`, or changing ndarray dimensionality).
 - The **compilation-relevant parts of the compiler configuration** (e.g. `arch`, `debug`, `opt_level`, `fast_math`).
-- The **device capabilities** of the target GPU (e.g. whether Vulkan/Metal expose 64-bit integers, atomics, or a given subgroup family), since the compiler generates different GPU code depending on them. This keeps an entry compiled for one device from being reused on another with different capabilities, for example when a cache directory is shared across machines.
+- The **device capabilities** of the target GPU (e.g. whether Vulkan/Metal expose 64-bit integers, atomics, or a particular family of [subgroup](subgroup.md) operations), since the compiler generates different GPU code depending on them. This keeps an entry compiled for one device from being reused on another with different capabilities, for example when a cache directory is shared across machines.
 - **Template parameter values** (since they are baked into the compiled kernel).
 
 When any of these change, the resulting key is different, so a new compilation occurs and a new entry is stored. Previous entries remain on disk - multiple cached versions coexist. You do not need to manually clear the cache when making code changes - the hash mismatch causes a transparent recompilation.


### PR DESCRIPTION
The 'Cache keying' section (not an advanced/internal section) used the compiler term 'codegen', which an end user is not expected to know. Reword to 'the compiler generates different GPU code depending on them'.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
