### PR TITLE
[Debug] Make QD_DUMP_CFG no longer change cfg behavior

### DIFF
--- a/docs/source/user_guide/optimization_passes.md
+++ b/docs/source/user_guide/optimization_passes.md
@@ -85,7 +85,7 @@ These environment variables dump the IR so you can see the effect of each pass. 
 
 - `QD_DUMP_IR=1` - writes an IR snapshot at each major pipeline stage (after lowering, before/after each simplify, after offload).
 - `QD_DUMP_SIMPLIFY=1` - writes an IR snapshot after every individual pass on every iteration of the simplify loop. Verbose, but it shows exactly which pass changed what.
-- `QD_DUMP_CFG=1` - writes the control-flow graph itself. (This also forces the CFG pass back onto the whole-kernel path so the complete graph can be dumped.)
+- `QD_DUMP_CFG=1` - writes the control-flow graph itself, at the granularity the compiler actually uses: one graph per offloaded task once the kernel has been offloaded (files suffixed `_task<N>`), and the whole-kernel graph before offload and for kernels that are never offloaded. It is observation-only - enabling it does not change which optimizations run or how the kernel is compiled, it only writes the graph out.
 
 Setting `qd.init(print_ir=True)` prints the IR to the console at pipeline stages instead of writing files.
 

--- a/docs/source/user_guide/optimization_passes.md
+++ b/docs/source/user_guide/optimization_passes.md
@@ -67,7 +67,7 @@ Building and analyzing the CFG is the most expensive optimization in the pipelin
 
 ## Controlling the passes
 
-All of these are fields of `CompileConfig`, so you set them at `qd.init(...)` (or via the matching `QD_<UPPERCASE_NAME>` environment variable). See [qd.init options](./init_options.md) for the full list and the environment-variable convention.
+All of these are fields of `CompileConfig` (the Quadrants compiler-configuration object built from your `qd.init(...)` arguments), so you set them at `qd.init(...)` (or via the matching `QD_<UPPERCASE_NAME>` environment variable). See [qd.init options](./init_options.md) for the full list and the environment-variable convention.
 
 | Option | Default | Effect |
 |--------|---------|--------|

--- a/docs/source/user_guide/optimization_passes.md
+++ b/docs/source/user_guide/optimization_passes.md
@@ -85,7 +85,7 @@ These environment variables dump the IR so you can see the effect of each pass. 
 
 - `QD_DUMP_IR=1` - writes an IR snapshot at each major pipeline stage (after lowering, before/after each simplify, after offload).
 - `QD_DUMP_SIMPLIFY=1` - writes an IR snapshot after every individual pass on every iteration of the simplify loop. Verbose, but it shows exactly which pass changed what.
-- `QD_DUMP_CFG=1` - writes the control-flow graph itself, at the granularity the compiler actually uses: one graph per offloaded task once the kernel has been offloaded (files suffixed `_task<N>`), and the whole-kernel graph before offload and for kernels that are never offloaded. It is observation-only - enabling it does not change which optimizations run or how the kernel is compiled, it only writes the graph out.
+- `QD_DUMP_CFG=1` - writes the control-flow graph itself, at the granularity the compiler actually uses: one graph per offloaded task once the kernel has been offloaded (files suffixed `_task<N>`), and the whole-kernel graph before offload and for kernels that are never offloaded.
 
 Setting `qd.init(print_ir=True)` prints the IR to the console at pipeline stages instead of writing files.
 

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -65,6 +65,9 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   for (int i = 0; i < offloads.size(); i++) {
     auto compile_func = [&, i] {
       tlctx_.fetch_this_thread_struct_module();
+      // This task is lowered in isolation on a worker thread with a one-task block, so record its kernel-wide
+      // index for QD_DUMP_CFG so per-task CFG dumps from these concurrent tasks don't collide on the same file.
+      irpass::ScopedTaskCodegenId dump_task_id_guard(i);
       auto offload = irpass::analysis::clone(offloads[i].get());
       irpass::re_id(offload.get());
 

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -14,6 +14,7 @@
 #endif
 #include "quadrants/system/timer.h"
 #include "quadrants/ir/analysis.h"
+#include "quadrants/ir/statements.h"
 #include "quadrants/ir/transforms.h"
 #include "quadrants/analysis/offline_cache_util.h"
 
@@ -63,10 +64,12 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   auto &offloads = block->statements;
   std::vector<std::unique_ptr<LLVMCompiledTask>> data(offloads.size());
   for (int i = 0; i < offloads.size(); i++) {
+    // Record each task's kernel-wide index (clone() carries it onto the per-task copy below). Each task is then
+    // lowered in isolation, where its one-task block's local index is always 0, so QD_DUMP_CFG reads this to give
+    // per-task CFG dumps a collision-free `_task<i>` name. Unconditional and inert -- never affects codegen.
+    offloads[i]->as<OffloadedStmt>()->task_index = i;
     auto compile_func = [&, i] {
       tlctx_.fetch_this_thread_struct_module();
-      // Record this task's kernel-wide id so QD_DUMP_CFG per-task dumps from concurrent workers don't collide.
-      irpass::ScopedTaskCodegenId dump_task_id_guard(i);
       auto offload = irpass::analysis::clone(offloads[i].get());
       irpass::re_id(offload.get());
 

--- a/quadrants/codegen/codegen.cpp
+++ b/quadrants/codegen/codegen.cpp
@@ -65,8 +65,7 @@ LLVMCompiledKernel KernelCodeGen::compile_kernel_to_module() {
   for (int i = 0; i < offloads.size(); i++) {
     auto compile_func = [&, i] {
       tlctx_.fetch_this_thread_struct_module();
-      // This task is lowered in isolation on a worker thread with a one-task block, so record its kernel-wide
-      // index for QD_DUMP_CFG so per-task CFG dumps from these concurrent tasks don't collide on the same file.
+      // Record this task's kernel-wide id so QD_DUMP_CFG per-task dumps from concurrent workers don't collide.
       irpass::ScopedTaskCodegenId dump_task_id_guard(i);
       auto offload = irpass::analysis::clone(offloads[i].get());
       irpass::re_id(offload.get());

--- a/quadrants/ir/statements.cpp
+++ b/quadrants/ir/statements.cpp
@@ -415,6 +415,7 @@ std::unique_ptr<Stmt> OffloadedStmt::clone() const {
   new_stmt->graph_parallel_region_id = graph_parallel_region_id;
   new_stmt->checkpoint_id = checkpoint_id;
   new_stmt->graph_do_while_level_id = graph_do_while_level_id;
+  new_stmt->task_index = task_index;
   new_stmt->loop_name = loop_name;
   // Shared-pointer copy: the captured trip-count `SizeExpr` is read-only after `determine_ad_stack_size`
   // populates it in `compile_to_offloads`, and LLVM codegen clones each offload at `codegen.cpp:68`

--- a/quadrants/ir/statements.h
+++ b/quadrants/ir/statements.h
@@ -1427,6 +1427,11 @@ class OffloadedStmt : public Stmt {
   // launch-context level table to rebuild nested graph_do_while loops.
   int graph_do_while_level_id{-1};
 
+  // Kernel-wide index of this task among the kernel's offloaded tasks (`-1` until numbered). Set unconditionally
+  // by `compile_kernel_to_module` before per-task codegen; currently read only to give QD_DUMP_CFG per-task CFG
+  // dumps a stable, collision-free `_task<N>` suffix. Pure metadata: never affects the compiled result.
+  int task_index{-1};
+
   // Pre-chunking loop trip-count `SizeExpr` captured by `determine_ad_stack_size`. Set on adstack-bearing
   // range-for tasks before `make_cpu_multithreaded_range_for` rewrites the loop into per-thread chunks, so the
   // SizeExpr still describes the original user-loop bound (handles both compile-time constants and

--- a/quadrants/ir/transforms.h
+++ b/quadrants/ir/transforms.h
@@ -43,19 +43,6 @@ bool cfg_optimization(const CompileConfig &config,
                       const std::string &kernel_name = "unknown",
                       const std::string &phase = "");
 
-// RAII: records this thread's task id while KernelCodeGen::compile_kernel_to_module lowers one task in isolation
-// (a one-task block), so cfg_optimization can name QD_DUMP_CFG per-task dumps by real index instead of colliding
-// on "_task0". No effect unless QD_DUMP_CFG is set.
-class ScopedTaskCodegenId {
- public:
-  explicit ScopedTaskCodegenId(int task_id);
-  ~ScopedTaskCodegenId();
-  ScopedTaskCodegenId(const ScopedTaskCodegenId &) = delete;
-  ScopedTaskCodegenId &operator=(const ScopedTaskCodegenId &) = delete;
-
- private:
-  std::optional<int> prev_;
-};
 bool alg_simp(IRNode *root, const CompileConfig &config);
 bool demote_operations(IRNode *root, const CompileConfig &config);
 bool binary_op_simplify(IRNode *root, const CompileConfig &config);

--- a/quadrants/ir/transforms.h
+++ b/quadrants/ir/transforms.h
@@ -42,6 +42,22 @@ bool cfg_optimization(const CompileConfig &config,
                       const std::optional<ControlFlowGraph::LiveVarAnalysisConfig> &lva_config_opt = std::nullopt,
                       const std::string &kernel_name = "unknown",
                       const std::string &phase = "");
+
+// Records, for the current thread, the kernel-wide index of the offloaded task being compiled in isolation.
+// KernelCodeGen::compile_kernel_to_module lowers each task on its own worker thread with the IR being a one-task
+// block, so cfg_optimization cannot derive the task's kernel-wide index itself. QD_DUMP_CFG reads this to name
+// per-task CFG dumps by real index, so concurrent tasks don't all collide on the "_task0" file. No effect unless
+// QD_DUMP_CFG is set; nullopt (its default) in whole-kernel contexts, where the index is taken from the block.
+class ScopedTaskCodegenId {
+ public:
+  explicit ScopedTaskCodegenId(int task_id);
+  ~ScopedTaskCodegenId();
+  ScopedTaskCodegenId(const ScopedTaskCodegenId &) = delete;
+  ScopedTaskCodegenId &operator=(const ScopedTaskCodegenId &) = delete;
+
+ private:
+  std::optional<int> prev_;
+};
 bool alg_simp(IRNode *root, const CompileConfig &config);
 bool demote_operations(IRNode *root, const CompileConfig &config);
 bool binary_op_simplify(IRNode *root, const CompileConfig &config);

--- a/quadrants/ir/transforms.h
+++ b/quadrants/ir/transforms.h
@@ -43,11 +43,9 @@ bool cfg_optimization(const CompileConfig &config,
                       const std::string &kernel_name = "unknown",
                       const std::string &phase = "");
 
-// Records, for the current thread, the kernel-wide index of the offloaded task being compiled in isolation.
-// KernelCodeGen::compile_kernel_to_module lowers each task on its own worker thread with the IR being a one-task
-// block, so cfg_optimization cannot derive the task's kernel-wide index itself. QD_DUMP_CFG reads this to name
-// per-task CFG dumps by real index, so concurrent tasks don't all collide on the "_task0" file. No effect unless
-// QD_DUMP_CFG is set; nullopt (its default) in whole-kernel contexts, where the index is taken from the block.
+// RAII: records this thread's task id while KernelCodeGen::compile_kernel_to_module lowers one task in isolation
+// (a one-task block), so cfg_optimization can name QD_DUMP_CFG per-task dumps by real index instead of colliding
+// on "_task0". No effect unless QD_DUMP_CFG is set.
 class ScopedTaskCodegenId {
  public:
   explicit ScopedTaskCodegenId(int task_id);

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -33,6 +33,22 @@ std::vector<OffloadedStmt *> collect_offloaded_tasks(IRNode *root) {
   return tasks;
 }
 
+// Suffix for a CFG dump filename. dump_graph_to_file writes "<kernel>_CFG<suffix>.txt", so this yields
+// "_<phase>_before_cfg_opt" / "_<phase>_post_cfg_opt" (the phase segment is dropped when |phase| is empty). For
+// per-task dumps, |task_index| adds a "_task<N>" segment so sibling tasks of the same kernel do not overwrite
+// each other's files.
+std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<int> task_index = std::nullopt) {
+  std::string suffix;
+  if (!phase.empty()) {
+    suffix += "_" + phase;
+  }
+  if (task_index.has_value()) {
+    suffix += "_task" + std::to_string(task_index.value());
+  }
+  suffix += post ? "_post_cfg_opt" : "_before_cfg_opt";
+  return suffix;
+}
+
 // Build and optimize a control-flow graph for a SINGLE offloaded task, scoped to that task alone.
 //
 // The task is temporarily moved into a throwaway wrapper block and run through the normal Block ->
@@ -51,11 +67,28 @@ std::vector<OffloadedStmt *> collect_offloaded_tasks(IRNode *root) {
 // the CFG spanning only one task, every global address -- fields, external tensors, and the global-temporary
 // buffer that carries scalars between tasks -- is therefore treated as live-in and live-out of the task, so no
 // store a sibling task may read is eliminated and no value is forwarded across a task (device-launch) boundary.
+//
+// QD_DUMP_CFG is observation-only here: when |dump_cfg| is set, the task's scoped CFG is written out before (and,
+// when the optimization runs, after) its per-task analyses, so the dump reflects the exact per-task graph the
+// compiler works on -- it never changes which optimizations run. The |real_matrix_enabled| path runs no per-task
+// analyses (matching the whole-kernel path); when it is set we only build+dump the "before" graph if dumping, and
+// skip entirely when not dumping so the no-op real-matrix behavior is preserved.
 bool optimize_one_task(Block *parent,
                        OffloadedStmt *off,
                        bool after_lower_access,
                        bool autodiff_enabled,
-                       const std::optional<ControlFlowGraph::LiveVarAnalysisConfig> &lva_config_opt) {
+                       bool real_matrix_enabled,
+                       const std::optional<ControlFlowGraph::LiveVarAnalysisConfig> &lva_config_opt,
+                       bool dump_cfg,
+                       const CompileConfig &config,
+                       const std::string &kernel_name,
+                       const std::string &phase,
+                       int task_index) {
+  // Nothing to do when the per-task optimization is disabled (real-matrix path) and we are not dumping: skip the
+  // CFG build so the no-op behavior of the real-matrix post-offload path is preserved exactly.
+  if (real_matrix_enabled && !dump_cfg) {
+    return false;
+  }
   const int location = parent->locate(off);
   QD_ASSERT(location != -1);
   Block wrapper;
@@ -65,12 +98,20 @@ bool optimize_one_task(Block *parent,
     // |cfg| holds raw pointers into |wrapper| (its container nodes) and into the task's own sub-blocks; keep
     // both alive until the analyses are done, then move the task back before |wrapper| leaves scope.
     auto cfg = analysis::build_cfg(&wrapper);
-    cfg->simplify_graph();
-    if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
-      modified = true;
+    if (dump_cfg) {
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, task_index));
     }
-    if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
-      modified = true;
+    if (!real_matrix_enabled) {
+      cfg->simplify_graph();
+      if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
+        modified = true;
+      }
+      if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
+        modified = true;
+      }
+      if (dump_cfg) {
+        cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_index));
+      }
     }
   }
   parent->insert(wrapper.extract(off), location);
@@ -92,6 +133,11 @@ bool cfg_optimization(const CompileConfig &config,
   const char *dump_cfg_env = std::getenv(DUMP_CFG_ENV.data());
   const bool dump_cfg = dump_cfg_env != nullptr && std::string(dump_cfg_env) == "1";
 
+  // QD_DUMP_CFG is observation-only: it must NOT change which path runs or which optimizations run -- it only
+  // controls whether the CFG is written out. So the path selection below is identical with or without the dump,
+  // and the graph is dumped at the granularity the compiler actually uses (per offloaded task post-offload,
+  // whole-kernel otherwise). The dump therefore reflects the real compilation instead of forcing it.
+
   // Per-offloaded-task scoping. Once the kernel is offloaded we optimize each task's CFG independently; and we
   // deliberately DITCH the expensive whole-kernel cfg_optimization in the pre-offload phase, relying on the
   // post-offload per-task cfg below to do the store-to-load forwarding + dead-store elimination once tasks
@@ -99,45 +145,50 @@ bool cfg_optimization(const CompileConfig &config,
   // pre-offload kernel IR -- where there are no tasks to scope to -- and dominate compile time. cfg_optimization
   // is an optimization, not a correctness pass, so dropping it pre-offload is safe; the only thing lost is
   // cross-task forwarding/DSE on the monolithic IR, which is invalid across separate device launches anyway.
-  // QD_DUMP_CFG forces the whole-kernel path so the full graph can still be dumped for debugging.
-  if (!dump_cfg) {
-    auto tasks = collect_offloaded_tasks(root);
-    if (!tasks.empty()) {
-      // Post-offload: per-task store-to-load forwarding + dead-store elimination (skipped for the real-matrix
-      // path, matching the whole-kernel path which runs no analyses there).
-      bool result_modified = false;
-      if (!real_matrix_enabled) {
-        auto *block = root->as<Block>();
-        for (auto *off : tasks) {
-          result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, lva_config_opt);
-        }
-      }
-      // TODO: implement cfg->dead_instruction_elimination()
-      die(root);  // remove unused allocas across the whole kernel
-      return result_modified;
+  auto tasks = collect_offloaded_tasks(root);
+  if (!tasks.empty()) {
+    // Post-offload: per-task store-to-load forwarding + dead-store elimination (skipped for the real-matrix
+    // path, matching the whole-kernel path which runs no analyses there). With QD_DUMP_CFG each task's CFG is
+    // dumped before/after its own optimization; the "_task<N>" suffix keeps sibling tasks from overwriting.
+    bool result_modified = false;
+    auto *block = root->as<Block>();
+    int task_index = 0;
+    for (auto *off : tasks) {
+      result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, real_matrix_enabled,
+                                           lva_config_opt, dump_cfg, config, kernel_name, phase, task_index);
+      ++task_index;
     }
-    // No offloaded tasks yet. Within compile_to_offloads these are the pre-offload full_simplify calls on the
-    // monolithic kernel IR (the phases below, all *before* irpass::offload): their whole-kernel cfg is the
-    // (super-linear) reaching-definition / store-to-load analysis that dominates compile time, and it is
-    // redundant because the post-offload per-task cfg ("simplify_III" onward) redoes the intra-task
-    // store-to-load forwarding + dead-store elimination once tasks exist. So for exactly those phases we ditch
-    // cfg, keeping only the cheap dead-alloca cleanup. For ANY other caller of full_simplify on non-offloaded
-    // IR (unit tests, standalone blocks / function bodies that are never offloaded), we must still run the
-    // whole-kernel cfg below, or its forwarding/DSE would be silently lost -- so we fall through.
-    const bool pre_offload_compile_phase =
-        phase == "simplify_I" || phase == "simplify_II" || phase == "pre_autodiff" || phase == "post_autodiff";
-    if (pre_offload_compile_phase) {
-      die(root);
-      return false;
-    }
-    // else: fall through to the whole-kernel cfg path below.
+    // TODO: implement cfg->dead_instruction_elimination()
+    die(root);  // remove unused allocas across the whole kernel
+    return result_modified;
   }
+  // No offloaded tasks yet. Within compile_to_offloads these are the pre-offload full_simplify calls on the
+  // monolithic kernel IR (the phases below, all *before* irpass::offload): their whole-kernel cfg is the
+  // (super-linear) reaching-definition / store-to-load analysis that dominates compile time, and it is
+  // redundant because the post-offload per-task cfg ("simplify_III" onward) redoes the intra-task
+  // store-to-load forwarding + dead-store elimination once tasks exist. So for exactly those phases we ditch
+  // cfg, keeping only the cheap dead-alloca cleanup. For ANY other caller of full_simplify on non-offloaded
+  // IR (unit tests, standalone blocks / function bodies that are never offloaded), we must still run the
+  // whole-kernel cfg below, or its forwarding/DSE would be silently lost -- so we fall through.
+  const bool pre_offload_compile_phase =
+      phase == "simplify_I" || phase == "simplify_II" || phase == "pre_autodiff" || phase == "post_autodiff";
+  if (pre_offload_compile_phase) {
+    // cfg optimization is intentionally not run in these phases. With QD_DUMP_CFG we still build a whole-kernel
+    // CFG purely to dump the "before" graph for debugging: build_cfg does not mutate the IR and no optimization
+    // runs, so this stays observation-only. There is no "post" dump because nothing changes the graph.
+    if (dump_cfg) {
+      auto cfg = analysis::build_cfg(root);
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false));
+    }
+    die(root);
+    return false;
+  }
+  // else: fall through to the whole-kernel cfg path below.
 
   auto cfg = analysis::build_cfg(root);
 
   if (dump_cfg) {
-    std::string suffix = phase.empty() ? "_before_cfg_opt" : ("_" + phase + "_before_cfg_opt");
-    cfg->dump_graph_to_file(config, kernel_name, suffix);
+    cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false));
   }
 
   bool result_modified = false;
@@ -152,8 +203,7 @@ bool cfg_optimization(const CompileConfig &config,
     }
 
     if (dump_cfg) {
-      std::string suffix = phase.empty() ? "_post_cfg_opt" : ("_" + phase + "_post_cfg_opt");
-      cfg->dump_graph_to_file(config, kernel_name, suffix);
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true));
     }
   }
   // TODO: implement cfg->dead_instruction_elimination()

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -12,8 +12,8 @@ namespace irpass {
 
 namespace {
 
-// Kernel-wide index of the offloaded task whose lowering is running on this thread, or nullopt in whole-kernel
-// contexts. Set via ScopedTaskCodegenId; read only to disambiguate QD_DUMP_CFG per-task dump filenames.
+// Kernel-wide id of the task being lowered on this thread (nullopt off codegen workers); set by
+// ScopedTaskCodegenId, used only to name QD_DUMP_CFG per-task dumps.
 thread_local std::optional<int> t_task_codegen_id = std::nullopt;
 
 // Collect the top-level offloaded tasks of |root| iff |root| is an already-offloaded kernel body, i.e. a Block
@@ -63,9 +63,8 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
 // conservative across it: reaching-definition seeds every global pointer live-in and live-variable seeds every
 // global store destination live-out, so nothing is forwarded or eliminated across the launch boundary.
 //
-// |run_optimization| (false on the real-matrix path, which supports no CFG optimization) gates the optimization
-// only; |dump_cfg| gates only the dumps. They are independent: QD_DUMP_CFG never changes what optimization runs,
-// and when optimization is off the CFG is still built and its "before" graph dumped for observation.
+// |run_optimization| gates the optimization, |dump_cfg| the dumps, independently: with optimization off
+// (real-matrix path) the "before" graph is still dumped, and QD_DUMP_CFG never changes what runs.
 bool optimize_one_task(Block *parent,
                        OffloadedStmt *off,
                        bool after_lower_access,
@@ -129,9 +128,8 @@ bool cfg_optimization(const CompileConfig &config,
   const char *dump_cfg_env = std::getenv(DUMP_CFG_ENV.data());
   const bool dump_cfg = dump_cfg_env != nullptr && std::string(dump_cfg_env) == "1";
 
-  // QD_DUMP_CFG is observation-only: it only controls whether the CFG is written, never which path or which
-  // optimizations run. The graph is dumped at the granularity actually used (per offloaded task post-offload,
-  // whole-kernel otherwise), so it reflects real compilation instead of forcing it.
+  // QD_DUMP_CFG is observation-only: it never changes the path or which optimizations run, only whether the CFG
+  // is written -- at the granularity actually used (per task post-offload, whole-kernel otherwise).
 
   // Post-offload we optimize each task's CFG independently; pre-offload (no tasks yet) we DITCH the whole-kernel
   // cfg_optimization, whose super-linear reaching-definition / forwarding analyses on the monolithic IR dominate
@@ -140,20 +138,18 @@ bool cfg_optimization(const CompileConfig &config,
   // the intra-task forwarding + DSE once tasks exist.
   auto tasks = collect_offloaded_tasks(root);
   if (!tasks.empty()) {
-    // Per-task store-to-load forwarding + dead-store elimination. The real-matrix path supports no CFG
-    // optimization (matching the whole-kernel path, which runs no analyses there), but QD_DUMP_CFG still dumps
-    // each task's "before" graph so the dump stays complete and observation-only.
+    // Per-task store-to-load forwarding + dead-store elimination, skipped on the real-matrix path (like the
+    // whole-kernel path) -- but QD_DUMP_CFG still dumps each task's "before" graph there.
     const bool run_optimization = !real_matrix_enabled;
     bool result_modified = false;
     auto *block = root->as<Block>();
     int task_index = 0;
     for (auto *off : tasks) {
-      // During isolated per-task codegen the block holds one task and its kernel-wide index is only known via
-      // t_task_codegen_id; in whole-kernel contexts the tasks are in order, so the loop index is that index.
+      // Kernel-wide task id: t_task_codegen_id during isolated per-task codegen (one-task block), else the
+      // loop index (whole-kernel, tasks in order).
       const int dump_task_id = t_task_codegen_id.value_or(task_index);
       ++task_index;
-      // Nothing to do for this task when we neither optimize nor dump: skip the CFG build so QD_DUMP_CFG stays
-      // zero-cost when off.
+      // Nothing to optimize or dump: skip the CFG build (keeps QD_DUMP_CFG zero-cost when off).
       if (!run_optimization && !dump_cfg) {
         continue;
       }
@@ -171,8 +167,8 @@ bool cfg_optimization(const CompileConfig &config,
   const bool pre_offload_compile_phase =
       phase == "simplify_I" || phase == "simplify_II" || phase == "pre_autodiff" || phase == "post_autodiff";
   if (pre_offload_compile_phase) {
-    // cfg optimization is intentionally skipped here; QD_DUMP_CFG still builds a whole-kernel CFG only to dump the
-    // "before" graph (build_cfg does not mutate IR, no optimization runs). No "post" dump: nothing changes it.
+    // Optimization is skipped here; QD_DUMP_CFG still builds the CFG only to dump the "before" graph (build_cfg
+    // does not mutate IR). No "post" dump -- nothing changed it.
     if (dump_cfg) {
       auto cfg = analysis::build_cfg(root);
       cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, t_task_codegen_id));
@@ -182,9 +178,8 @@ bool cfg_optimization(const CompileConfig &config,
   }
   // else: fall through to the whole-kernel cfg path below.
 
-  // This path also handles a bare OffloadedStmt root (not a Block), e.g. make_block_local's full_simplify, which
-  // runs on the per-task codegen worker; t_task_codegen_id then scopes the dump name so concurrent tasks do not
-  // collide. It is nullopt (no suffix) for genuine whole-kernel / function-body roots off the codegen threads.
+  // Also handles a bare OffloadedStmt root (e.g. make_block_local's full_simplify on a codegen worker): there
+  // t_task_codegen_id scopes the dump name so concurrent tasks do not collide; nullopt for whole-kernel roots.
   auto cfg = analysis::build_cfg(root);
 
   if (dump_cfg) {

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -33,10 +33,6 @@ std::vector<OffloadedStmt *> collect_offloaded_tasks(IRNode *root) {
   return tasks;
 }
 
-// Suffix for a CFG dump filename. dump_graph_to_file writes "<kernel>_CFG<suffix>.txt", so this yields
-// "_<phase>_before_cfg_opt" / "_<phase>_post_cfg_opt" (the phase segment is dropped when |phase| is empty). For
-// per-task dumps, |task_index| adds a "_task<N>" segment so sibling tasks of the same kernel do not overwrite
-// each other's files.
 std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<int> task_index = std::nullopt) {
   std::string suffix;
   if (!phase.empty()) {

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -80,6 +80,11 @@ bool optimize_one_task(Block *parent,
                        const std::string &kernel_name,
                        const std::string &phase,
                        int task_id) {
+  // Neither optimizing nor dumping: the CFG would be pure throwaway work, so bail before touching the IR. Past
+  // this point |dump_cfg| only ever gates the dump calls.
+  if (!run_optimization && !dump_cfg) {
+    return false;
+  }
   const int location = parent->locate(off);
   QD_ASSERT(location != -1);
   Block wrapper;
@@ -126,7 +131,8 @@ bool cfg_optimization(const CompileConfig &config,
 
   // Post-offload we optimize each task's CFG independently; pre-offload (no tasks yet) we DITCH the whole-kernel
   // cfg_optimization, whose super-linear reaching-definition / forwarding analyses on the monolithic IR dominate
-  // compile time.
+  // compile time. Safe to ditch: cross-task forwarding/DSE on the monolithic IR is invalid across the separate
+  // device launches anyway.
   auto tasks = collect_offloaded_tasks(root);
   if (!tasks.empty()) {
     // Per-task store-to-load forwarding + dead-store elimination, skipped on the real-matrix path (like the
@@ -140,10 +146,6 @@ bool cfg_optimization(const CompileConfig &config,
       // holds one task); before codegen numbers them the tasks sit here in kernel order, so the loop index fits.
       const int dump_task_id = off->task_index >= 0 ? off->task_index : task_index;
       ++task_index;
-      // Nothing to optimize or dump: skip the CFG build (keeps QD_DUMP_CFG zero-cost when off).
-      if (!run_optimization && !dump_cfg) {
-        continue;
-      }
       result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, run_optimization,
                                            lva_config_opt, dump_cfg, config, kernel_name, phase, dump_task_id);
     }

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -63,12 +63,6 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
 // the CFG spanning only one task, every global address -- fields, external tensors, and the global-temporary
 // buffer that carries scalars between tasks -- is therefore treated as live-in and live-out of the task, so no
 // store a sibling task may read is eliminated and no value is forwarded across a task (device-launch) boundary.
-//
-// QD_DUMP_CFG is observation-only here: when |dump_cfg| is set, the task's scoped CFG is written out before (and,
-// when the optimization runs, after) its per-task analyses, so the dump reflects the exact per-task graph the
-// compiler works on -- it never changes which optimizations run. The |real_matrix_enabled| path runs no per-task
-// analyses (matching the whole-kernel path); when it is set we only build+dump the "before" graph if dumping, and
-// skip entirely when not dumping so the no-op real-matrix behavior is preserved.
 bool optimize_one_task(Block *parent,
                        OffloadedStmt *off,
                        bool after_lower_access,

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -128,8 +128,8 @@ bool cfg_optimization(const CompileConfig &config,
       auto *block = root->as<Block>();
       int task_index = 0;
       for (auto *off : tasks) {
-        result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, lva_config_opt,
-                                             dump_cfg, config, kernel_name, phase, task_index);
+        result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, lva_config_opt, dump_cfg,
+                                             config, kernel_name, phase, task_index);
         ++task_index;
       }
     }

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -45,40 +45,29 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
   return suffix;
 }
 
-// Build and optimize a control-flow graph for a SINGLE offloaded task, scoped to that task alone.
+// Build and optimize the CFG for a SINGLE offloaded task, scoped to that task alone.
 //
-// The task is temporarily moved into a throwaway wrapper block and run through the normal Block ->
-// OffloadedStmt CFG construction, then moved back, leaving the IR shape unchanged. Building through a wrapper
-// (instead of stitching together per-sub-block CFGs) is what makes this correct: the resulting CFG is
-// byte-for-byte the slice that the whole-kernel CFG would build for this one task -- including the offloaded
-// for-body's implicit-loop `continue` edges (which are wired by visit(OffloadedStmt), not by visit(Block)), the
-// prologue/body/epilogue chaining, and the body's is_parallel_executed flag. Optimizing each sub-block in
-// isolation would drop the `continue` loop-back edges and wrongly dead-store-eliminate a global store that
-// precedes a `continue` (regression caught by test_cfg_continue).
+// The task is moved into a throwaway wrapper block, run through the normal Block -> OffloadedStmt CFG
+// construction, then moved back (IR shape unchanged). The wrapper build yields byte-for-byte the slice the
+// whole-kernel CFG would build for this task -- notably the offloaded for-body's implicit-loop `continue` edges,
+// whose loss would wrongly dead-store-eliminate a global store preceding a `continue` (regression:
+// test_cfg_continue).
 //
-// Scoping the analyses to one task is semantics-preserving because each offloaded task is a separate device
-// launch and the existing CFG boundary seeding is conservative across the launch boundary:
-// reaching_definition_analysis seeds the start node with all global pointers ("may already hold data") and
-// live_variable_analysis seeds the final node with all global store destinations ("may be read later"). With
-// the CFG spanning only one task, every global address -- fields, external tensors, and the global-temporary
-// buffer that carries scalars between tasks -- is therefore treated as live-in and live-out of the task, so no
-// store a sibling task may read is eliminated and no value is forwarded across a task (device-launch) boundary.
+// Scoping to one task is safe because each task is a separate device launch and CFG boundary seeding is
+// conservative across it: reaching-definition seeds every global pointer live-in and live-variable seeds every
+// global store destination live-out, so nothing is forwarded or eliminated across the launch boundary.
+//
+// QD_DUMP_CFG only gates the dumps (before/after this task's optimization); it never changes what runs here.
 bool optimize_one_task(Block *parent,
                        OffloadedStmt *off,
                        bool after_lower_access,
                        bool autodiff_enabled,
-                       bool real_matrix_enabled,
                        const std::optional<ControlFlowGraph::LiveVarAnalysisConfig> &lva_config_opt,
                        bool dump_cfg,
                        const CompileConfig &config,
                        const std::string &kernel_name,
                        const std::string &phase,
                        int task_index) {
-  // Nothing to do when the per-task optimization is disabled (real-matrix path) and we are not dumping: skip the
-  // CFG build so the no-op behavior of the real-matrix post-offload path is preserved exactly.
-  if (real_matrix_enabled && !dump_cfg) {
-    return false;
-  }
   const int location = parent->locate(off);
   QD_ASSERT(location != -1);
   Block wrapper;
@@ -91,17 +80,15 @@ bool optimize_one_task(Block *parent,
     if (dump_cfg) {
       cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, task_index));
     }
-    if (!real_matrix_enabled) {
-      cfg->simplify_graph();
-      if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
-        modified = true;
-      }
-      if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
-        modified = true;
-      }
-      if (dump_cfg) {
-        cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_index));
-      }
+    cfg->simplify_graph();
+    if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
+      modified = true;
+    }
+    if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
+      modified = true;
+    }
+    if (dump_cfg) {
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_index));
     }
   }
   parent->insert(wrapper.extract(off), location);
@@ -123,49 +110,42 @@ bool cfg_optimization(const CompileConfig &config,
   const char *dump_cfg_env = std::getenv(DUMP_CFG_ENV.data());
   const bool dump_cfg = dump_cfg_env != nullptr && std::string(dump_cfg_env) == "1";
 
-  // QD_DUMP_CFG is observation-only: it must NOT change which path runs or which optimizations run -- it only
-  // controls whether the CFG is written out. So the path selection below is identical with or without the dump,
-  // and the graph is dumped at the granularity the compiler actually uses (per offloaded task post-offload,
-  // whole-kernel otherwise). The dump therefore reflects the real compilation instead of forcing it.
+  // QD_DUMP_CFG is observation-only: it only controls whether the CFG is written, never which path or which
+  // optimizations run. The graph is dumped at the granularity actually used (per offloaded task post-offload,
+  // whole-kernel otherwise), so it reflects real compilation instead of forcing it.
 
-  // Per-offloaded-task scoping. Once the kernel is offloaded we optimize each task's CFG independently; and we
-  // deliberately DITCH the expensive whole-kernel cfg_optimization in the pre-offload phase, relying on the
-  // post-offload per-task cfg below to do the store-to-load forwarding + dead-store elimination once tasks
-  // exist. The expensive (super-linear) reaching-definition / forwarding analyses otherwise run on the monolithic
-  // pre-offload kernel IR -- where there are no tasks to scope to -- and dominate compile time. cfg_optimization
-  // is an optimization, not a correctness pass, so dropping it pre-offload is safe; the only thing lost is
-  // cross-task forwarding/DSE on the monolithic IR, which is invalid across separate device launches anyway.
+  // Post-offload we optimize each task's CFG independently; pre-offload (no tasks yet) we DITCH the whole-kernel
+  // cfg_optimization, whose super-linear reaching-definition / forwarding analyses on the monolithic IR dominate
+  // compile time. Safe because cfg_optimization is an optimization, not correctness, and cross-task forwarding/DSE
+  // on the monolithic IR is invalid across separate device launches anyway; the post-offload per-task cfg redoes
+  // the intra-task forwarding + DSE once tasks exist.
   auto tasks = collect_offloaded_tasks(root);
   if (!tasks.empty()) {
-    // Post-offload: per-task store-to-load forwarding + dead-store elimination (skipped for the real-matrix
-    // path, matching the whole-kernel path which runs no analyses there). With QD_DUMP_CFG each task's CFG is
-    // dumped before/after its own optimization; the "_task<N>" suffix keeps sibling tasks from overwriting.
+    // Per-task store-to-load forwarding + dead-store elimination, skipped for the real-matrix path (matching the
+    // whole-kernel path, which runs no analyses there).
     bool result_modified = false;
-    auto *block = root->as<Block>();
-    int task_index = 0;
-    for (auto *off : tasks) {
-      result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, real_matrix_enabled,
-                                           lva_config_opt, dump_cfg, config, kernel_name, phase, task_index);
-      ++task_index;
+    if (!real_matrix_enabled) {
+      auto *block = root->as<Block>();
+      int task_index = 0;
+      for (auto *off : tasks) {
+        result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, lva_config_opt,
+                                             dump_cfg, config, kernel_name, phase, task_index);
+        ++task_index;
+      }
     }
     // TODO: implement cfg->dead_instruction_elimination()
     die(root);  // remove unused allocas across the whole kernel
     return result_modified;
   }
-  // No offloaded tasks yet. Within compile_to_offloads these are the pre-offload full_simplify calls on the
-  // monolithic kernel IR (the phases below, all *before* irpass::offload): their whole-kernel cfg is the
-  // (super-linear) reaching-definition / store-to-load analysis that dominates compile time, and it is
-  // redundant because the post-offload per-task cfg ("simplify_III" onward) redoes the intra-task
-  // store-to-load forwarding + dead-store elimination once tasks exist. So for exactly those phases we ditch
-  // cfg, keeping only the cheap dead-alloca cleanup. For ANY other caller of full_simplify on non-offloaded
-  // IR (unit tests, standalone blocks / function bodies that are never offloaded), we must still run the
-  // whole-kernel cfg below, or its forwarding/DSE would be silently lost -- so we fall through.
+  // No offloaded tasks yet. For the pre-offload compile phases below the whole-kernel cfg is redundant (the
+  // post-offload per-task cfg redoes the intra-task forwarding + DSE once tasks exist), so we ditch it and keep
+  // only the cheap dead-alloca cleanup. Any OTHER non-offloaded caller (unit tests, standalone blocks / function
+  // bodies that are never offloaded) must still run the whole-kernel cfg below, or lose its forwarding/DSE.
   const bool pre_offload_compile_phase =
       phase == "simplify_I" || phase == "simplify_II" || phase == "pre_autodiff" || phase == "post_autodiff";
   if (pre_offload_compile_phase) {
-    // cfg optimization is intentionally not run in these phases. With QD_DUMP_CFG we still build a whole-kernel
-    // CFG purely to dump the "before" graph for debugging: build_cfg does not mutate the IR and no optimization
-    // runs, so this stays observation-only. There is no "post" dump because nothing changes the graph.
+    // cfg optimization is intentionally skipped here; QD_DUMP_CFG still builds a whole-kernel CFG only to dump the
+    // "before" graph (build_cfg does not mutate IR, no optimization runs). No "post" dump: nothing changes it.
     if (dump_cfg) {
       auto cfg = analysis::build_cfg(root);
       cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false));

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -61,11 +61,14 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
 // conservative across it: reaching-definition seeds every global pointer live-in and live-variable seeds every
 // global store destination live-out, so nothing is forwarded or eliminated across the launch boundary.
 //
-// QD_DUMP_CFG only gates the dumps (before/after this task's optimization); it never changes what runs here.
+// |run_optimization| (false on the real-matrix path, which supports no CFG optimization) gates the optimization
+// only; |dump_cfg| gates only the dumps. They are independent: QD_DUMP_CFG never changes what optimization runs,
+// and when optimization is off the CFG is still built and its "before" graph dumped for observation.
 bool optimize_one_task(Block *parent,
                        OffloadedStmt *off,
                        bool after_lower_access,
                        bool autodiff_enabled,
+                       bool run_optimization,
                        const std::optional<ControlFlowGraph::LiveVarAnalysisConfig> &lva_config_opt,
                        bool dump_cfg,
                        const CompileConfig &config,
@@ -84,15 +87,17 @@ bool optimize_one_task(Block *parent,
     if (dump_cfg) {
       cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, task_id));
     }
-    cfg->simplify_graph();
-    if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
-      modified = true;
-    }
-    if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
-      modified = true;
-    }
-    if (dump_cfg) {
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_id));
+    if (run_optimization) {
+      cfg->simplify_graph();
+      if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
+        modified = true;
+      }
+      if (cfg->dead_store_elimination(after_lower_access, lva_config_opt)) {
+        modified = true;
+      }
+      if (dump_cfg) {
+        cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_id));
+      }
     }
   }
   parent->insert(wrapper.extract(off), location);
@@ -133,20 +138,25 @@ bool cfg_optimization(const CompileConfig &config,
   // the intra-task forwarding + DSE once tasks exist.
   auto tasks = collect_offloaded_tasks(root);
   if (!tasks.empty()) {
-    // Per-task store-to-load forwarding + dead-store elimination, skipped for the real-matrix path (matching the
-    // whole-kernel path, which runs no analyses there).
+    // Per-task store-to-load forwarding + dead-store elimination. The real-matrix path supports no CFG
+    // optimization (matching the whole-kernel path, which runs no analyses there), but QD_DUMP_CFG still dumps
+    // each task's "before" graph so the dump stays complete and observation-only.
+    const bool run_optimization = !real_matrix_enabled;
     bool result_modified = false;
-    if (!real_matrix_enabled) {
-      auto *block = root->as<Block>();
-      int task_index = 0;
-      for (auto *off : tasks) {
-        // During isolated per-task codegen the block holds one task and its kernel-wide index is only known via
-        // t_task_codegen_id; in whole-kernel contexts the tasks are in order, so the loop index is that index.
-        const int dump_task_id = t_task_codegen_id.value_or(task_index);
-        result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, lva_config_opt, dump_cfg,
-                                             config, kernel_name, phase, dump_task_id);
-        ++task_index;
+    auto *block = root->as<Block>();
+    int task_index = 0;
+    for (auto *off : tasks) {
+      // During isolated per-task codegen the block holds one task and its kernel-wide index is only known via
+      // t_task_codegen_id; in whole-kernel contexts the tasks are in order, so the loop index is that index.
+      const int dump_task_id = t_task_codegen_id.value_or(task_index);
+      ++task_index;
+      // Nothing to do for this task when we neither optimize nor dump: skip the CFG build so QD_DUMP_CFG stays
+      // zero-cost when off.
+      if (!run_optimization && !dump_cfg) {
+        continue;
       }
+      result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, run_optimization,
+                                           lva_config_opt, dump_cfg, config, kernel_name, phase, dump_task_id);
     }
     // TODO: implement cfg->dead_instruction_elimination()
     die(root);  // remove unused allocas across the whole kernel

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -173,17 +173,20 @@ bool cfg_optimization(const CompileConfig &config,
     // "before" graph (build_cfg does not mutate IR, no optimization runs). No "post" dump: nothing changes it.
     if (dump_cfg) {
       auto cfg = analysis::build_cfg(root);
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false));
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, t_task_codegen_id));
     }
     die(root);
     return false;
   }
   // else: fall through to the whole-kernel cfg path below.
 
+  // This path also handles a bare OffloadedStmt root (not a Block), e.g. make_block_local's full_simplify, which
+  // runs on the per-task codegen worker; t_task_codegen_id then scopes the dump name so concurrent tasks do not
+  // collide. It is nullopt (no suffix) for genuine whole-kernel / function-body roots off the codegen threads.
   auto cfg = analysis::build_cfg(root);
 
   if (dump_cfg) {
-    cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false));
+    cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, t_task_codegen_id));
   }
 
   bool result_modified = false;
@@ -198,7 +201,7 @@ bool cfg_optimization(const CompileConfig &config,
     }
 
     if (dump_cfg) {
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true));
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, t_task_codegen_id));
     }
   }
   // TODO: implement cfg->dead_instruction_elimination()

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -52,10 +52,12 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
 // Build and optimize the CFG for a SINGLE offloaded task, scoped to that task alone.
 //
 // The task is moved into a throwaway wrapper block, run through the normal Block -> OffloadedStmt CFG
-// construction, then moved back (IR shape unchanged). The wrapper build yields byte-for-byte the slice the
-// whole-kernel CFG would build for this task -- notably the offloaded for-body's implicit-loop `continue` edges,
-// whose loss would wrongly dead-store-eliminate a global store preceding a `continue` (regression:
-// test_cfg_continue).
+// construction, then moved back (IR shape unchanged). Building through a wrapper -- instead of stitching
+// together per-sub-block CFGs -- yields byte-for-byte the slice the whole-kernel CFG would build for this task:
+// the offloaded for-body's implicit-loop `continue` edges (wired by visit(OffloadedStmt), not visit(Block)), the
+// prologue/body/epilogue chaining, and the body's is_parallel_executed flag. Optimizing each sub-block in
+// isolation would drop the `continue` loop-back edges and wrongly dead-store-eliminate a global store preceding
+// a `continue` (regression: test_cfg_continue).
 //
 // Scoping to one task is safe because each task is a separate device launch and CFG boundary seeding is
 // conservative across it: reaching-definition seeds every global pointer live-in and live-variable seeds every

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -62,9 +62,6 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
 // Scoping to one task is safe because each task is a separate device launch and CFG boundary seeding is
 // conservative across it: reaching-definition seeds every global pointer live-in and live-variable seeds every
 // global store destination live-out, so nothing is forwarded or eliminated across the launch boundary.
-//
-// |run_optimization| gates the optimization, |dump_cfg| the dumps, independently: with optimization off
-// (real-matrix path) the "before" graph is still dumped, and QD_DUMP_CFG never changes what runs.
 bool optimize_one_task(Block *parent,
                        OffloadedStmt *off,
                        bool after_lower_access,
@@ -128,25 +125,18 @@ bool cfg_optimization(const CompileConfig &config,
   const char *dump_cfg_env = std::getenv(DUMP_CFG_ENV.data());
   const bool dump_cfg = dump_cfg_env != nullptr && std::string(dump_cfg_env) == "1";
 
-  // QD_DUMP_CFG is observation-only: it never changes the path or which optimizations run, only whether the CFG
-  // is written -- at the granularity actually used (per task post-offload, whole-kernel otherwise).
-
   // Post-offload we optimize each task's CFG independently; pre-offload (no tasks yet) we DITCH the whole-kernel
   // cfg_optimization, whose super-linear reaching-definition / forwarding analyses on the monolithic IR dominate
-  // compile time. Safe because cfg_optimization is an optimization, not correctness, and cross-task forwarding/DSE
-  // on the monolithic IR is invalid across separate device launches anyway; the post-offload per-task cfg redoes
-  // the intra-task forwarding + DSE once tasks exist.
+  // compile time.
   auto tasks = collect_offloaded_tasks(root);
   if (!tasks.empty()) {
     // Per-task store-to-load forwarding + dead-store elimination, skipped on the real-matrix path (like the
-    // whole-kernel path) -- but QD_DUMP_CFG still dumps each task's "before" graph there.
+    // whole-kernel path).
     const bool run_optimization = !real_matrix_enabled;
     bool result_modified = false;
     auto *block = root->as<Block>();
     int task_index = 0;
     for (auto *off : tasks) {
-      // Kernel-wide task id: t_task_codegen_id during isolated per-task codegen (one-task block), else the
-      // loop index (whole-kernel, tasks in order).
       const int dump_task_id = t_task_codegen_id.value_or(task_index);
       ++task_index;
       // Nothing to optimize or dump: skip the CFG build (keeps QD_DUMP_CFG zero-cost when off).

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -12,6 +12,10 @@ namespace irpass {
 
 namespace {
 
+// Kernel-wide index of the offloaded task whose lowering is running on this thread, or nullopt in whole-kernel
+// contexts. Set via ScopedTaskCodegenId; read only to disambiguate QD_DUMP_CFG per-task dump filenames.
+thread_local std::optional<int> t_task_codegen_id = std::nullopt;
+
 // Collect the top-level offloaded tasks of |root| iff |root| is an already-offloaded kernel body, i.e. a Block
 // whose statements are all OffloadedStmt. Returns an empty vector otherwise (pre-offload IR, function bodies,
 // non-Block roots). This is what lets the caller tell "post-offload" (run per-task cfg) from "pre-offload /
@@ -67,7 +71,7 @@ bool optimize_one_task(Block *parent,
                        const CompileConfig &config,
                        const std::string &kernel_name,
                        const std::string &phase,
-                       int task_index) {
+                       int task_id) {
   const int location = parent->locate(off);
   QD_ASSERT(location != -1);
   Block wrapper;
@@ -78,7 +82,7 @@ bool optimize_one_task(Block *parent,
     // both alive until the analyses are done, then move the task back before |wrapper| leaves scope.
     auto cfg = analysis::build_cfg(&wrapper);
     if (dump_cfg) {
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, task_index));
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, task_id));
     }
     cfg->simplify_graph();
     if (cfg->store_to_load_forwarding(after_lower_access, autodiff_enabled)) {
@@ -88,7 +92,7 @@ bool optimize_one_task(Block *parent,
       modified = true;
     }
     if (dump_cfg) {
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_index));
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, task_id));
     }
   }
   parent->insert(wrapper.extract(off), location);
@@ -96,6 +100,14 @@ bool optimize_one_task(Block *parent,
 }
 
 }  // namespace
+
+ScopedTaskCodegenId::ScopedTaskCodegenId(int task_id) : prev_(t_task_codegen_id) {
+  t_task_codegen_id = task_id;
+}
+
+ScopedTaskCodegenId::~ScopedTaskCodegenId() {
+  t_task_codegen_id = prev_;
+}
 
 bool cfg_optimization(const CompileConfig &config,
                       IRNode *root,
@@ -128,8 +140,11 @@ bool cfg_optimization(const CompileConfig &config,
       auto *block = root->as<Block>();
       int task_index = 0;
       for (auto *off : tasks) {
+        // During isolated per-task codegen the block holds one task and its kernel-wide index is only known via
+        // t_task_codegen_id; in whole-kernel contexts the tasks are in order, so the loop index is that index.
+        const int dump_task_id = t_task_codegen_id.value_or(task_index);
         result_modified |= optimize_one_task(block, off, after_lower_access, autodiff_enabled, lva_config_opt, dump_cfg,
-                                             config, kernel_name, phase, task_index);
+                                             config, kernel_name, phase, dump_task_id);
         ++task_index;
       }
     }

--- a/quadrants/transforms/cfg_optimization.cpp
+++ b/quadrants/transforms/cfg_optimization.cpp
@@ -12,10 +12,6 @@ namespace irpass {
 
 namespace {
 
-// Kernel-wide id of the task being lowered on this thread (nullopt off codegen workers); set by
-// ScopedTaskCodegenId, used only to name QD_DUMP_CFG per-task dumps.
-thread_local std::optional<int> t_task_codegen_id = std::nullopt;
-
 // Collect the top-level offloaded tasks of |root| iff |root| is an already-offloaded kernel body, i.e. a Block
 // whose statements are all OffloadedStmt. Returns an empty vector otherwise (pre-offload IR, function bodies,
 // non-Block roots). This is what lets the caller tell "post-offload" (run per-task cfg) from "pre-offload /
@@ -47,6 +43,17 @@ std::string cfg_dump_suffix(const std::string &phase, bool post, std::optional<i
   }
   suffix += post ? "_post_cfg_opt" : "_before_cfg_opt";
   return suffix;
+}
+
+// Kernel-wide task index for naming |root|'s CFG dump, or nullopt when |root| has none. Set only when |root| is a
+// bare offloaded task (make_block_local's per-task full_simplify runs on a clone that carries OffloadedStmt::
+// task_index); a Block or never-offloaded root has no index, so its dump keeps the unsuffixed whole-kernel name.
+std::optional<int> root_task_index(IRNode *root) {
+  auto *off = root->cast<OffloadedStmt>();
+  if (off != nullptr && off->task_index >= 0) {
+    return off->task_index;
+  }
+  return std::nullopt;
 }
 
 // Build and optimize the CFG for a SINGLE offloaded task, scoped to that task alone.
@@ -104,14 +111,6 @@ bool optimize_one_task(Block *parent,
 
 }  // namespace
 
-ScopedTaskCodegenId::ScopedTaskCodegenId(int task_id) : prev_(t_task_codegen_id) {
-  t_task_codegen_id = task_id;
-}
-
-ScopedTaskCodegenId::~ScopedTaskCodegenId() {
-  t_task_codegen_id = prev_;
-}
-
 bool cfg_optimization(const CompileConfig &config,
                       IRNode *root,
                       bool after_lower_access,
@@ -137,7 +136,9 @@ bool cfg_optimization(const CompileConfig &config,
     auto *block = root->as<Block>();
     int task_index = 0;
     for (auto *off : tasks) {
-      const int dump_task_id = t_task_codegen_id.value_or(task_index);
+      // Prefer the task's own kernel-wide index (set for the isolated per-task codegen path, where the block
+      // holds one task); before codegen numbers them the tasks sit here in kernel order, so the loop index fits.
+      const int dump_task_id = off->task_index >= 0 ? off->task_index : task_index;
       ++task_index;
       // Nothing to optimize or dump: skip the CFG build (keeps QD_DUMP_CFG zero-cost when off).
       if (!run_optimization && !dump_cfg) {
@@ -161,19 +162,19 @@ bool cfg_optimization(const CompileConfig &config,
     // does not mutate IR). No "post" dump -- nothing changed it.
     if (dump_cfg) {
       auto cfg = analysis::build_cfg(root);
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, t_task_codegen_id));
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, root_task_index(root)));
     }
     die(root);
     return false;
   }
   // else: fall through to the whole-kernel cfg path below.
 
-  // Also handles a bare OffloadedStmt root (e.g. make_block_local's full_simplify on a codegen worker): there
-  // t_task_codegen_id scopes the dump name so concurrent tasks do not collide; nullopt for whole-kernel roots.
+  // Also handles a bare OffloadedStmt root (e.g. make_block_local's full_simplify on a codegen worker): its
+  // task_index scopes the dump name so concurrent tasks do not collide; nullopt for whole-kernel roots.
   auto cfg = analysis::build_cfg(root);
 
   if (dump_cfg) {
-    cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, t_task_codegen_id));
+    cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/false, root_task_index(root)));
   }
 
   bool result_modified = false;
@@ -188,7 +189,7 @@ bool cfg_optimization(const CompileConfig &config,
     }
 
     if (dump_cfg) {
-      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, t_task_codegen_id));
+      cfg->dump_graph_to_file(config, kernel_name, cfg_dump_suffix(phase, /*post=*/true, root_task_index(root)));
     }
   }
   // TODO: implement cfg->dead_instruction_elimination()

--- a/tests/python/test_dump_cfg_per_task.py
+++ b/tests/python/test_dump_cfg_per_task.py
@@ -1,4 +1,5 @@
 import pathlib
+import re
 
 import pytest
 
@@ -50,3 +51,10 @@ def test_dump_cfg_is_per_task(tmp_path: pathlib.Path, monkeypatch: pytest.Monkey
     # Each optimized task is dumped both before and after its own per-task optimization.
     assert any("_task0_before_cfg_opt" in f for f in cfg_files), cfg_files
     assert any("_task0_post_cfg_opt" in f for f in cfg_files), cfg_files
+
+    # The per-task codegen phases (before_lower_access, simplify_IV, ...) lower each task in isolation on its own
+    # worker thread, where the local task index is always 0. If the dump used that local index, only the
+    # whole-kernel post-offload phase would emit a task1 file and every codegen phase would collide on task0.
+    # Requiring task1 dumps from more than one distinct phase pins that the kernel-wide task id is used instead.
+    phases_with_task1 = {m.group(1) for f in cfg_files if (m := re.search(r"_CFG_(.+)_task1_", f))}
+    assert len(phases_with_task1) >= 2, f"Expected task1 dumps from multiple phases, got {sorted(phases_with_task1)}"

--- a/tests/python/test_dump_cfg_per_task.py
+++ b/tests/python/test_dump_cfg_per_task.py
@@ -1,0 +1,52 @@
+import pathlib
+
+import pytest
+
+import quadrants as qd
+
+from tests import test_utils
+
+
+@test_utils.test(offline_cache=False)
+def test_dump_cfg_is_per_task(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
+    # QD_DUMP_CFG must be observation-only: once a kernel is offloaded, cfg_optimization runs per offloaded task,
+    # and the dump must follow that granularity (one graph per task, "_task<N>" suffix) rather than forcing the
+    # CFG back onto the whole-kernel path. Two independent top-level loops become two offloaded tasks, so we
+    # expect per-task dump files for task0 and task1.
+    monkeypatch.setenv("QD_DUMP_CFG", "1")
+    qd.lang.impl.current_cfg().debug_dump_path = str(tmp_path)
+
+    n = 128
+    a = qd.ndarray(qd.i32, shape=(n,))
+    b = qd.ndarray(qd.i32, shape=(n,))
+
+    @qd.kernel
+    def two_loops(
+        a: qd.types.ndarray(dtype=qd.i32, ndim=1),
+        b: qd.types.ndarray(dtype=qd.i32, ndim=1),
+    ):
+        for i in range(n):
+            a[i] = i
+        for i in range(n):
+            b[i] = i * 2
+
+    two_loops(a, b)
+    qd.sync()
+
+    a_np = a.to_numpy()
+    b_np = b.to_numpy()
+    for i in range(n):
+        assert a_np[i] == i
+        assert b_np[i] == i * 2
+
+    cfg_files = [f.name for f in tmp_path.glob("*_CFG_*")]
+    assert cfg_files, f"No CFG dumps written under {tmp_path}"
+
+    task0 = [f for f in cfg_files if "_task0_" in f]
+    task1 = [f for f in cfg_files if "_task1_" in f]
+    assert task0, f"No per-task (task0) CFG dumps found; got {cfg_files}"
+    assert task1, f"No per-task (task1) CFG dumps found; got {cfg_files}"
+
+    # Each optimized task is dumped both before and after its own per-task optimization.
+    assert any("_task0_before_cfg_opt" in f for f in cfg_files), cfg_files
+    assert any("_task0_post_cfg_opt" in f for f in cfg_files), cfg_files


### PR DESCRIPTION
QD_DUMP_CFG=1 forced cfg_optimization back onto the whole-kernel path, so the graph it dumped for debugging was not the graph the compiler actually builds and optimizes: post-offload the compiler optimizes each offloaded task's CFG independently, but with the dump on it ran (and dumped) one whole-kernel CFG. Enabling a debug dump thus changed which optimizations ran.

Decouple the dump from path selection: dump_cfg no longer gates which path runs, only whether the CFG is written. The graph is dumped at the granularity actually used -- per offloaded task post-offload (files suffixed _task<N> so sibling tasks don't overwrite), whole-kernel before offload and for kernels that are never offloaded. In the pre-offload phases where cfg_optimization is deliberately ditched, QD_DUMP_CFG builds a whole-kernel CFG only to dump the before graph, running no optimization. build_cfg/dump don't mutate IR, so the compiled kernel is identical with the dump on or off.

Adds test_dump_cfg_per_task asserting per-task dump files are produced for a two-task kernel, and updates optimization_passes.md.

Issue: #

### Brief Summary

copilot:summary

### Walkthrough

copilot:walkthrough
