### PR TITLE
[Lang] Parse `T | None` optional kernel-arg annotations (W4)

### DIFF
--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -211,7 +211,7 @@ A `qd.Tensor` parameter also accepts **external arrays** - `numpy.ndarray` and `
 
 ### Declaring that an argument may be `None`: `T | None`
 
-To make it explicit in the signature that an argument accepts `None`, spell it `T | None`. This is supported for three annotation families: `qd.Tensor`, `qd.types.Template`, and `qd.types.NDArray`. The `typing.Optional[T]` spelling is equivalent for the two class-style families (`qd.Tensor`, `qd.types.Template`) but not for `qd.types.NDArray[...]`: a subscripted ndarray annotation evaluates to an instance that `typing.Optional[...]` cannot wrap (it raises `TypeError` while the annotation is being constructed), so ndarray arguments must use the `T | None` spelling. Guard the present-only operations with `qd.static(x is not None)` exactly as above:
+To make it explicit in the signature that an argument accepts `None`, spell it `T | None`. This is supported for three annotation families: `qd.Tensor`, `qd.types.Template`, and [`qd.types.NDArray`](tensor_types.md). The `typing.Optional[T]` spelling is equivalent for the two class-style families (`qd.Tensor`, `qd.types.Template`) but not for `qd.types.NDArray[...]`: a subscripted ndarray annotation evaluates to an instance that `typing.Optional[...]` cannot wrap (it raises `TypeError` while the annotation is being constructed), so ndarray arguments must use the `T | None` spelling. Guard the present-only operations with `qd.static(x is not None)` exactly as above:
 
 ```python
 @qd.kernel

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -222,8 +222,8 @@ def add_bias(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor | None):
         else:
             out[i] = qd.f32(i)
 
-add_bias(out, None)          # absent: the bias branch is specialized away
-add_bias(out, qd.wrap(bias)) # present
+add_bias(out, None)   # absent: the bias branch is specialized away
+add_bias(out, bias)   # present: bias is a qd.Tensor (or a bare field / ndarray)
 ```
 
 The bare `qd.Tensor` spelling (above) keeps accepting `None`, so `x: qd.Tensor` and `x: qd.Tensor | None` behave the same at runtime; `T | None` is the form to prefer when you want the optionality visible in the signature. Only the two-member `T | None` union is accepted - other unions (`A | B`, `A | B | None`) and `| None` on any other annotation family are rejected at kernel-registration time.

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -209,7 +209,7 @@ For a parameter annotated `qd.Tensor`, calls to the same kernel may alternate am
 
 ### Declaring that an argument may be `None`: `T | None`
 
-To make it explicit in the signature that an argument accepts `None`, spell it `T | None` (equivalently `typing.Optional[T]`). This is supported for three annotation families: `qd.Tensor`, `qd.types.Template`, and `qd.types.NDArray`. Guard the present-only operations with `qd.static(x is not None)` exactly as above:
+To make it explicit in the signature that an argument accepts `None`, spell it `T | None`. This is supported for three annotation families: `qd.Tensor`, `qd.types.Template`, and `qd.types.NDArray`. The `typing.Optional[T]` spelling is equivalent for the two class-style families (`qd.Tensor`, `qd.types.Template`) but not for `qd.types.NDArray[...]`: a subscripted ndarray annotation evaluates to an instance that `typing.Optional[...]` cannot wrap (it raises `TypeError` while the annotation is being constructed), so ndarray arguments must use the `T | None` spelling. Guard the present-only operations with `qd.static(x is not None)` exactly as above:
 
 ```python
 @qd.kernel

--- a/docs/source/user_guide/tensor.md
+++ b/docs/source/user_guide/tensor.md
@@ -207,6 +207,27 @@ Inside the kernel the argument is the bare impl rather than the wrapper, so kern
 
 For a parameter annotated `qd.Tensor`, calls to the same kernel may alternate among a wrapper, its bare field or ndarray implementation, and `None`. If callers can pass `None`, guard tensor operations with [`qd.static()`](static.md), for example `if qd.static(x is not None):`; the guarded operations are not traced for the `None` specialization. The parameter remains annotated `qd.Tensor`, and `None` must be passed explicitly.
 
+### Declaring that an argument may be `None`: `T | None`
+
+To make it explicit in the signature that an argument accepts `None`, spell it `T | None` (equivalently `typing.Optional[T]`). This is supported for three annotation families: `qd.Tensor`, `qd.types.Template`, and `qd.types.NDArray`. Guard the present-only operations with `qd.static(x is not None)` exactly as above:
+
+```python
+@qd.kernel
+def add_bias(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor | None):
+    for i in range(out.shape[0]):
+        if qd.static(bias is not None):
+            out[i] = qd.f32(i) + bias[i]
+        else:
+            out[i] = qd.f32(i)
+
+add_bias(out, None)          # absent: the bias branch is specialized away
+add_bias(out, qd.wrap(bias)) # present
+```
+
+The bare `qd.Tensor` spelling (above) keeps accepting `None`, so `x: qd.Tensor` and `x: qd.Tensor | None` behave the same at runtime; `T | None` is the form to prefer when you want the optionality visible in the signature. Only the two-member `T | None` union is accepted - other unions (`A | B`, `A | B | None`) and `| None` on any other annotation family are rejected at kernel-registration time.
+
+Support is not yet uniform at launch: `qd.Tensor | None` and `qd.types.Template | None` accept `None` now, but `qd.types.NDArray[...] | None` currently accepts only a present array - passing `None` raises at launch until optional ndarray slots land. The annotation parses either way, so signatures can already be written in the target form.
+
 `qd.Tensor` is also the right annotation when storing a tensor as a `dataclasses.dataclass` member:
 
 ```python

--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -73,6 +73,7 @@ from quadrants.types.utils import is_signed
 _TENSOR_T_NDARRAY_LAUNCH_ANNOTATION = ndarray_type.NdarrayType()
 
 from ._kernel_types import KernelBatchedArgType
+from ._optional_annotation import split_optional
 from ._template_mapper import TemplateMapper
 from ._template_mapper_hotpath import _is_external_array
 
@@ -168,62 +169,6 @@ def _get_frozen_dc_unwrapped(v: Any, fields_dict: dict) -> dict[str, Any]:
     return unwrapped
 
 
-_NoneType = type(None)
-
-
-def _is_optional_capable(inner) -> bool:
-    """Whether ``inner`` is an annotation family that handles an absent (``None``) value.
-
-    Optionality (``T | None``) is only meaningful for the three families in design.md: ``qd.Tensor`` and
-    ``qd.types.Template`` accept ``None`` at runtime today, and ``qd.types.NDArray`` accepts the spelling now with
-    runtime support deferred to the dual-nature-slot work (W5). Every other annotation family (dataclass, struct,
-    matrix, primitive, buffer view, ...) has no absent-value path, so recording it as optional would only defer a
-    confusing internal failure to launch time (e.g. ``getattr(None, field.name)`` for a dataclass slot). Reject those
-    at registration instead.
-    """
-    if inner is _TensorClass:
-        return True
-    if inner is template or isinstance(inner, template):  # qd.types.Template, class or instance
-        return True
-    # qd.types.NDArray, either the bare class or a subscripted ``NDArray[dtype, ndim]`` instance.
-    if inner is ndarray_type.NdarrayType or type(inner) is ndarray_type.NdarrayType:
-        return True
-    return False
-
-
-def _split_optional(annotation):
-    """Normalize a kernel-arg annotation, unwrapping the optional (``T | None`` / ``Optional[T]``) form.
-
-    Returns ``(inner, optional)``. For a non-optional annotation this is ``(annotation, False)``. For the optional
-    form it is ``(T, True)`` with the ``None`` stripped, so the caller can run ``inner`` through the existing
-    per-family validation unchanged and separately record that the slot accepts ``None``.
-
-    The three annotation families reach this uniformly for the ``|`` spelling: ``qd.Tensor`` and ``qd.types.Template``
-    are classes, so ``T | None`` (and ``typing.Optional[T]``) build a real union; ``qd.types.NDArray[...]`` is an
-    instance whose ``__or__`` shim yields an ``_OptionalNdarray`` marker. See design.md W4 and quadrants#831.
-
-    Only these three families may be made optional; ``T | None`` on any other family is rejected here rather than
-    silently recording an optional slot that has no absent-value handling (see ``_is_optional_capable``).
-    """
-    if isinstance(annotation, ndarray_type._OptionalNdarray):
-        return annotation.inner, True
-    if isinstance(annotation, types.UnionType) or typing.get_origin(annotation) is typing.Union:
-        args = typing.get_args(annotation)
-        non_none = tuple(a for a in args if a is not _NoneType)
-        if _NoneType not in args or len(non_none) != 1:
-            raise QuadrantsSyntaxError(
-                f"Quadrants kernels only support optional annotations of the form 'T | None', got: {annotation}"
-            )
-        inner = non_none[0]
-        if not _is_optional_capable(inner):
-            raise QuadrantsSyntaxError(
-                "Optional ('T | None') kernel arguments are only supported for qd.Tensor, qd.types.Template and "
-                f"qd.types.NDArray, got: {inner}"
-            )
-        return inner, True
-    return annotation, False
-
-
 class FuncBase:
     """
     Base class for Kernels and Funcs
@@ -304,7 +249,7 @@ class FuncBase:
                 elif self.is_kernel or self.is_real_function:
                     raise QuadrantsSyntaxError("Quadrants kernels parameters must be type annotated")
             else:
-                annotation, optional = _split_optional(annotation)
+                annotation, optional = split_optional(annotation)
                 annotation_type = type(annotation)
                 if annotation_type is ndarray_type.NdarrayType:
                     pass

--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -167,6 +167,33 @@ def _get_frozen_dc_unwrapped(v: Any, fields_dict: dict) -> dict[str, Any]:
     return unwrapped
 
 
+_NoneType = type(None)
+
+
+def _split_optional(annotation):
+    """Normalize a kernel-arg annotation, unwrapping the optional (``T | None`` / ``Optional[T]``) form.
+
+    Returns ``(inner, optional)``. For a non-optional annotation this is ``(annotation, False)``. For the optional
+    form it is ``(T, True)`` with the ``None`` stripped, so the caller can run ``inner`` through the existing
+    per-family validation unchanged and separately record that the slot accepts ``None``.
+
+    The three annotation families reach this uniformly for the ``|`` spelling: ``qd.Tensor`` and ``qd.types.Template``
+    are classes, so ``T | None`` (and ``typing.Optional[T]``) build a real union; ``qd.types.NDArray[...]`` is an
+    instance whose ``__or__`` shim yields an ``_OptionalNdarray`` marker. See design.md W4 and quadrants#831.
+    """
+    if isinstance(annotation, ndarray_type._OptionalNdarray):
+        return annotation.inner, True
+    if isinstance(annotation, types.UnionType) or typing.get_origin(annotation) is typing.Union:
+        args = typing.get_args(annotation)
+        non_none = tuple(a for a in args if a is not _NoneType)
+        if _NoneType not in args or len(non_none) != 1:
+            raise QuadrantsSyntaxError(
+                f"Quadrants kernels only support optional annotations of the form 'T | None', got: {annotation}"
+            )
+        return non_none[0], True
+    return annotation, False
+
+
 class FuncBase:
     """
     Base class for Kernels and Funcs
@@ -240,12 +267,14 @@ class FuncBase:
             if param.kind != inspect.Parameter.POSITIONAL_OR_KEYWORD:
                 raise QuadrantsSyntaxError('Quadrants kernels only support "positional or keyword" parameters')
             annotation = param.annotation
+            optional = False
             if param.annotation is inspect.Parameter.empty:
                 if i == 0 and (self.is_classkernel or self.is_classfunc):  # The |self| parameter
                     annotation = template()
                 elif self.is_kernel or self.is_real_function:
                     raise QuadrantsSyntaxError("Quadrants kernels parameters must be type annotated")
             else:
+                annotation, optional = _split_optional(annotation)
                 annotation_type = type(annotation)
                 if annotation_type is ndarray_type.NdarrayType:
                     pass
@@ -282,8 +311,8 @@ class FuncBase:
                     raise QuadrantsSyntaxError(
                         f"Invalid type annotation (argument {i}) of Quadrants kernel: {annotation}"
                     )
-            self.arg_metas.append(ArgMetadata(annotation, param.name, param.default))
-            self.orig_arguments.append(ArgMetadata(annotation, param.name, param.default))
+            self.arg_metas.append(ArgMetadata(annotation, param.name, param.default, optional=optional))
+            self.orig_arguments.append(ArgMetadata(annotation, param.name, param.default, optional=optional))
 
         self.template_slot_locations: list[int] = []
         for i, arg in enumerate(self.arg_metas):

--- a/python/quadrants/lang/_func_base.py
+++ b/python/quadrants/lang/_func_base.py
@@ -170,6 +170,26 @@ def _get_frozen_dc_unwrapped(v: Any, fields_dict: dict) -> dict[str, Any]:
 _NoneType = type(None)
 
 
+def _is_optional_capable(inner) -> bool:
+    """Whether ``inner`` is an annotation family that handles an absent (``None``) value.
+
+    Optionality (``T | None``) is only meaningful for the three families in design.md: ``qd.Tensor`` and
+    ``qd.types.Template`` accept ``None`` at runtime today, and ``qd.types.NDArray`` accepts the spelling now with
+    runtime support deferred to the dual-nature-slot work (W5). Every other annotation family (dataclass, struct,
+    matrix, primitive, buffer view, ...) has no absent-value path, so recording it as optional would only defer a
+    confusing internal failure to launch time (e.g. ``getattr(None, field.name)`` for a dataclass slot). Reject those
+    at registration instead.
+    """
+    if inner is _TensorClass:
+        return True
+    if inner is template or isinstance(inner, template):  # qd.types.Template, class or instance
+        return True
+    # qd.types.NDArray, either the bare class or a subscripted ``NDArray[dtype, ndim]`` instance.
+    if inner is ndarray_type.NdarrayType or type(inner) is ndarray_type.NdarrayType:
+        return True
+    return False
+
+
 def _split_optional(annotation):
     """Normalize a kernel-arg annotation, unwrapping the optional (``T | None`` / ``Optional[T]``) form.
 
@@ -180,6 +200,9 @@ def _split_optional(annotation):
     The three annotation families reach this uniformly for the ``|`` spelling: ``qd.Tensor`` and ``qd.types.Template``
     are classes, so ``T | None`` (and ``typing.Optional[T]``) build a real union; ``qd.types.NDArray[...]`` is an
     instance whose ``__or__`` shim yields an ``_OptionalNdarray`` marker. See design.md W4 and quadrants#831.
+
+    Only these three families may be made optional; ``T | None`` on any other family is rejected here rather than
+    silently recording an optional slot that has no absent-value handling (see ``_is_optional_capable``).
     """
     if isinstance(annotation, ndarray_type._OptionalNdarray):
         return annotation.inner, True
@@ -190,7 +213,13 @@ def _split_optional(annotation):
             raise QuadrantsSyntaxError(
                 f"Quadrants kernels only support optional annotations of the form 'T | None', got: {annotation}"
             )
-        return non_none[0], True
+        inner = non_none[0]
+        if not _is_optional_capable(inner):
+            raise QuadrantsSyntaxError(
+                "Optional ('T | None') kernel arguments are only supported for qd.Tensor, qd.types.Template and "
+                f"qd.types.NDArray, got: {inner}"
+            )
+        return inner, True
     return annotation, False
 
 

--- a/python/quadrants/lang/_optional_annotation.py
+++ b/python/quadrants/lang/_optional_annotation.py
@@ -1,9 +1,4 @@
-"""Parsing/validation for the optional (``T | None``) kernel-argument spelling.
-
-Self-contained helper used once by ``FuncBase.check_parameter_annotations`` to unwrap a ``T | None`` /
-``typing.Optional[T]`` annotation into ``(inner, optional)``. Kept out of ``_func_base.py`` so this feature adds a
-new module rather than growing the central kernel base class. See design.md W4.
-"""
+"""Unwrap the optional (``T | None``) spelling of a kernel-argument annotation."""
 
 import types
 import typing
@@ -16,38 +11,22 @@ _NoneType = type(None)
 
 
 def _is_optional_capable(inner) -> bool:
-    """Whether ``inner`` is an annotation family that handles an absent (``None``) value.
-
-    Optionality (``T | None``) is only meaningful for the three families in design.md: ``qd.Tensor`` and
-    ``qd.types.Template`` accept ``None`` at runtime today, and ``qd.types.NDArray`` accepts the spelling now with
-    runtime support deferred to the dual-nature-slot work (W5). Every other annotation family (dataclass, struct,
-    matrix, primitive, buffer view, ...) has no absent-value path, so recording it as optional would only defer a
-    confusing internal failure to launch time (e.g. ``getattr(None, field.name)`` for a dataclass slot). Reject those
-    at registration instead.
-    """
+    """The families with an absent-value path; ``T | None`` on anything else has no runtime meaning."""
     if inner is _TensorClass:
         return True
-    if inner is template or isinstance(inner, template):  # qd.types.Template, class or instance
+    if inner is template or isinstance(inner, template):
         return True
-    # qd.types.NDArray, either the bare class or a subscripted ``NDArray[dtype, ndim]`` instance.
+    # NDArray annotations are instances (``NDArray[dtype, ndim]``), so accept the bare class too.
     if inner is ndarray_type.NdarrayType or type(inner) is ndarray_type.NdarrayType:
         return True
     return False
 
 
 def split_optional(annotation):
-    """Normalize a kernel-arg annotation, unwrapping the optional (``T | None`` / ``Optional[T]``) form.
+    """Return ``(inner, optional)``, stripping ``None`` from an optional ``T | None`` annotation.
 
-    Returns ``(inner, optional)``. For a non-optional annotation this is ``(annotation, False)``. For the optional
-    form it is ``(T, True)`` with the ``None`` stripped, so the caller can run ``inner`` through the existing
-    per-family validation unchanged and separately record that the slot accepts ``None``.
-
-    The three annotation families reach this uniformly for the ``|`` spelling: ``qd.Tensor`` and ``qd.types.Template``
-    are classes, so ``T | None`` (and ``typing.Optional[T]``) build a real union; ``qd.types.NDArray[...]`` is an
-    instance whose ``__or__`` shim yields an ``_OptionalNdarray`` marker. See design.md W4 and quadrants#831.
-
-    Only these three families may be made optional; ``T | None`` on any other family is rejected here rather than
-    silently recording an optional slot that has no absent-value handling (see ``_is_optional_capable``).
+    Rejecting optionality on unsupported families here surfaces a bad annotation at kernel registration
+    instead of deep inside launch.
     """
     if isinstance(annotation, ndarray_type._OptionalNdarray):
         return annotation.inner, True

--- a/python/quadrants/lang/_optional_annotation.py
+++ b/python/quadrants/lang/_optional_annotation.py
@@ -1,0 +1,68 @@
+"""Parsing/validation for the optional (``T | None``) kernel-argument spelling.
+
+Self-contained helper used once by ``FuncBase.check_parameter_annotations`` to unwrap a ``T | None`` /
+``typing.Optional[T]`` annotation into ``(inner, optional)``. Kept out of ``_func_base.py`` so this feature adds a
+new module rather than growing the central kernel base class. See design.md W4.
+"""
+
+import types
+import typing
+
+from quadrants._tensor_wrapper import Tensor as _TensorClass
+from quadrants.lang.exception import QuadrantsSyntaxError
+from quadrants.types import ndarray_type, template
+
+_NoneType = type(None)
+
+
+def _is_optional_capable(inner) -> bool:
+    """Whether ``inner`` is an annotation family that handles an absent (``None``) value.
+
+    Optionality (``T | None``) is only meaningful for the three families in design.md: ``qd.Tensor`` and
+    ``qd.types.Template`` accept ``None`` at runtime today, and ``qd.types.NDArray`` accepts the spelling now with
+    runtime support deferred to the dual-nature-slot work (W5). Every other annotation family (dataclass, struct,
+    matrix, primitive, buffer view, ...) has no absent-value path, so recording it as optional would only defer a
+    confusing internal failure to launch time (e.g. ``getattr(None, field.name)`` for a dataclass slot). Reject those
+    at registration instead.
+    """
+    if inner is _TensorClass:
+        return True
+    if inner is template or isinstance(inner, template):  # qd.types.Template, class or instance
+        return True
+    # qd.types.NDArray, either the bare class or a subscripted ``NDArray[dtype, ndim]`` instance.
+    if inner is ndarray_type.NdarrayType or type(inner) is ndarray_type.NdarrayType:
+        return True
+    return False
+
+
+def split_optional(annotation):
+    """Normalize a kernel-arg annotation, unwrapping the optional (``T | None`` / ``Optional[T]``) form.
+
+    Returns ``(inner, optional)``. For a non-optional annotation this is ``(annotation, False)``. For the optional
+    form it is ``(T, True)`` with the ``None`` stripped, so the caller can run ``inner`` through the existing
+    per-family validation unchanged and separately record that the slot accepts ``None``.
+
+    The three annotation families reach this uniformly for the ``|`` spelling: ``qd.Tensor`` and ``qd.types.Template``
+    are classes, so ``T | None`` (and ``typing.Optional[T]``) build a real union; ``qd.types.NDArray[...]`` is an
+    instance whose ``__or__`` shim yields an ``_OptionalNdarray`` marker. See design.md W4 and quadrants#831.
+
+    Only these three families may be made optional; ``T | None`` on any other family is rejected here rather than
+    silently recording an optional slot that has no absent-value handling (see ``_is_optional_capable``).
+    """
+    if isinstance(annotation, ndarray_type._OptionalNdarray):
+        return annotation.inner, True
+    if isinstance(annotation, types.UnionType) or typing.get_origin(annotation) is typing.Union:
+        args = typing.get_args(annotation)
+        non_none = tuple(a for a in args if a is not _NoneType)
+        if _NoneType not in args or len(non_none) != 1:
+            raise QuadrantsSyntaxError(
+                f"Quadrants kernels only support optional annotations of the form 'T | None', got: {annotation}"
+            )
+        inner = non_none[0]
+        if not _is_optional_capable(inner):
+            raise QuadrantsSyntaxError(
+                "Optional ('T | None') kernel arguments are only supported for qd.Tensor, qd.types.Template and "
+                f"qd.types.NDArray, got: {inner}"
+            )
+        return inner, True
+    return annotation, False

--- a/python/quadrants/lang/kernel_arguments.py
+++ b/python/quadrants/lang/kernel_arguments.py
@@ -23,13 +23,20 @@ class ArgMetadata:
     Metadata about an argument to a function
     """
 
-    def __init__(self, annotation, name, default=inspect.Parameter.empty):
+    def __init__(self, annotation, name, default=inspect.Parameter.empty, optional=False):
         self.annotation = annotation
         self.name = name
         self.default = default
+        # True when the parameter was spelled ``T | None`` (or ``Optional[T]``). ``annotation`` holds the unwrapped
+        # ``T``; ``optional`` records that ``None`` is an accepted value for this slot. Consumed by the dual-nature
+        # ndarray slot handling (design.md W5); Tensor/Template slots already accept ``None`` regardless.
+        self.optional = optional
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}(annotation={self.annotation}, name={self.name}, default={self.default})"
+        return (
+            f"{self.__class__.__name__}(annotation={self.annotation}, name={self.name}, default={self.default}, "
+            f"optional={self.optional})"
+        )
 
 
 class SparseMatrixEntry:

--- a/python/quadrants/lang/kernel_arguments.py
+++ b/python/quadrants/lang/kernel_arguments.py
@@ -27,9 +27,7 @@ class ArgMetadata:
         self.annotation = annotation
         self.name = name
         self.default = default
-        # True when the parameter was spelled ``T | None`` (or ``Optional[T]``). ``annotation`` holds the unwrapped
-        # ``T``; ``optional`` records that ``None`` is an accepted value for this slot. Consumed by the dual-nature
-        # ndarray slot handling (design.md W5); Tensor/Template slots already accept ``None`` regardless.
+        # ``None`` is an accepted value for this slot (spelled ``T | None``); ``annotation`` is the unwrapped ``T``.
         self.optional = optional
 
     def __repr__(self) -> str:

--- a/python/quadrants/types/ndarray_type.py
+++ b/python/quadrants/types/ndarray_type.py
@@ -100,13 +100,9 @@ class NdarrayType:
         return cls(*args)
 
     def __or__(self, other):
-        # Shim so ``qd.types.NDArray[...] | None`` forms an optional-ndarray annotation. Needed only because
-        # ``NDArray[...]`` currently evaluates to an *instance* (see ``__class_getitem__`` above), so the interpreter
-        # cannot build a ``types.UnionType`` from it the way it can for the class-style ``qd.Tensor`` /
-        # ``qd.types.Template`` annotations. The kernel annotation validator recognizes the returned marker.
-        #
-        # TODO(quadrants#831): delete this shim once ``NDArray[...]`` evaluates to a type rather than an instance, at
-        # which point ``NDArray[...] | None`` yields a real ``types.UnionType`` handled by the generic union path.
+        # ``NDArray[...]`` is an instance, not a class, so ``|`` cannot build a ``types.UnionType`` the way it does
+        # for class-style annotations; hand back a marker the annotation validator understands instead.
+        # TODO(quadrants#831): drop this once ``NDArray[...]`` evaluates to a type.
         if other is None or other is type(None):
             return _OptionalNdarray(self)
         return NotImplemented
@@ -168,11 +164,7 @@ class NdarrayType:
 
 
 class _OptionalNdarray:
-    """Marker produced by ``qd.types.NDArray[...] | None``; see ``NdarrayType.__or__``.
-
-    Wraps the underlying :class:`NdarrayType` instance so the kernel annotation validator can unwrap it and record the
-    slot as optional. Superseded by quadrants#831 (delete alongside ``NdarrayType.__or__``).
-    """
+    """Marks ``NDArray[...] | None``; the validator unwraps ``.inner`` and records the slot as optional."""
 
     def __init__(self, inner: "NdarrayType"):
         self.inner = inner

--- a/python/quadrants/types/ndarray_type.py
+++ b/python/quadrants/types/ndarray_type.py
@@ -99,6 +99,18 @@ class NdarrayType:
             args = (args,)
         return cls(*args)
 
+    def __or__(self, other):
+        # Shim so ``qd.types.NDArray[...] | None`` forms an optional-ndarray annotation. Needed only because
+        # ``NDArray[...]`` currently evaluates to an *instance* (see ``__class_getitem__`` above), so the interpreter
+        # cannot build a ``types.UnionType`` from it the way it can for the class-style ``qd.Tensor`` /
+        # ``qd.types.Template`` annotations. The kernel annotation validator recognizes the returned marker.
+        #
+        # TODO(quadrants#831): delete this shim once ``NDArray[...]`` evaluates to a type rather than an instance, at
+        # which point ``NDArray[...] | None`` yields a real ``types.UnionType`` handled by the generic union path.
+        if other is None or other is type(None):
+            return _OptionalNdarray(self)
+        return NotImplemented
+
     def check_matched(self, ndarray_type: NdarrayTypeMetadata, arg_name: str):
         # FIXME(Haidong) Cannot use Vector/MatrixType due to circular import
         # Use the CompuoundType instead to determine the specific typs.
@@ -153,6 +165,20 @@ class NdarrayType:
     def to_dlpack(self) -> object:
         # needed for pyright
         raise NotImplementedError()
+
+
+class _OptionalNdarray:
+    """Marker produced by ``qd.types.NDArray[...] | None``; see ``NdarrayType.__or__``.
+
+    Wraps the underlying :class:`NdarrayType` instance so the kernel annotation validator can unwrap it and record the
+    slot as optional. Superseded by quadrants#831 (delete alongside ``NdarrayType.__or__``).
+    """
+
+    def __init__(self, inner: "NdarrayType"):
+        self.inner = inner
+
+    def __repr__(self):
+        return f"_OptionalNdarray(inner={self.inner!r})"
 
 
 ndarray = NdarrayType

--- a/tests/python/test_optional_annotation.py
+++ b/tests/python/test_optional_annotation.py
@@ -106,6 +106,23 @@ def test_multi_member_optional_union_is_rejected():
             pass
 
 
+def test_optional_unsupported_family_is_rejected():
+    """`T | None` is only for qd.Tensor / qd.types.Template / qd.types.NDArray. A family with no absent-value path
+    (here a dataclass) must be rejected at registration, not silently recorded as optional and left to crash with an
+    internal AttributeError when `None` reaches the dataclass launch branch."""
+    import dataclasses
+
+    @dataclasses.dataclass
+    class State:
+        a: qd.Tensor
+
+    with pytest.raises(QuadrantsSyntaxError, match="only supported for qd.Tensor"):
+
+        @qd.kernel
+        def k(s: State | None):
+            pass
+
+
 # ----------------------------------------------------------------------------
 # Runtime: qd.Tensor | None works end to end (both branches), just like the bare spelling.
 # ----------------------------------------------------------------------------

--- a/tests/python/test_optional_annotation.py
+++ b/tests/python/test_optional_annotation.py
@@ -1,0 +1,186 @@
+"""Tests for the ``T | None`` optional kernel-argument spelling (design.md W4).
+
+W4 makes ``T | None`` parse uniformly for the three annotation families (``qd.Tensor``, ``qd.types.Template``,
+``qd.types.NDArray[...]``) and records the slot as optional on its ``ArgMetadata``. ``qd.Tensor`` and
+``qd.types.Template`` slots already accept ``None`` at runtime, so for those two the union spelling works end to end
+here. ``qd.types.NDArray[...] | None`` parses and still works when a value is present; making ``None`` actually launch
+against an ndarray slot is W5, and the boundary is pinned below.
+"""
+
+import typing
+
+import numpy as np
+import pytest
+
+import quadrants as qd
+from quadrants.lang.exception import QuadrantsRuntimeTypeError, QuadrantsSyntaxError
+from quadrants.types.ndarray_type import NdarrayType
+
+from tests import test_utils
+
+# ----------------------------------------------------------------------------
+# Parse + normalization: the union spelling is accepted and the slot is marked optional.
+# These run at @qd.kernel decoration time and need no qd.init().
+# ----------------------------------------------------------------------------
+
+
+def _arg0(kernel):
+    return kernel._primal.arg_metas[0]
+
+
+def test_tensor_union_parses_and_marks_optional():
+    @qd.kernel
+    def k(x: qd.Tensor | None):
+        pass
+
+    meta = _arg0(k)
+    assert meta.optional is True
+    # None is stripped; the stored annotation is the bare qd.Tensor class, so downstream dispatch is unchanged.
+    assert meta.annotation is qd.Tensor
+
+
+def test_template_union_parses_and_marks_optional():
+    @qd.kernel
+    def k(x: qd.types.Template | None):
+        pass
+
+    meta = _arg0(k)
+    assert meta.optional is True
+    assert meta.annotation is qd.types.Template
+
+
+def test_ndarray_union_parses_and_preserves_spec():
+    @qd.kernel
+    def k(x: qd.types.NDArray[qd.f32, 1] | None):
+        pass
+
+    meta = _arg0(k)
+    assert meta.optional is True
+    # The dtype/ndim carried by the subscripted instance must survive the __or__ shim unwrap.
+    assert isinstance(meta.annotation, NdarrayType)
+    assert meta.annotation.ndim == 1
+    assert meta.annotation.dtype == qd.f32
+
+
+def test_optional_typing_form_parses_for_class_families():
+    """``typing.Optional[T]`` is equivalent to ``T | None`` for the two class-style families (design.md D1: the
+    ndarray family stays ``|``-only until issue 831, because ``Optional[instance]`` fails ``typing._type_check``)."""
+
+    @qd.kernel
+    def kt(x: typing.Optional[qd.Tensor]):
+        pass
+
+    @qd.kernel
+    def ktemplate(x: typing.Optional[qd.types.Template]):
+        pass
+
+    assert _arg0(kt).optional is True
+    assert _arg0(kt).annotation is qd.Tensor
+    assert _arg0(ktemplate).optional is True
+    assert _arg0(ktemplate).annotation is qd.types.Template
+
+
+def test_non_optional_annotation_stays_non_optional():
+    @qd.kernel
+    def k(x: qd.Tensor):
+        pass
+
+    assert _arg0(k).optional is False
+    assert _arg0(k).annotation is qd.Tensor
+
+
+def test_union_without_none_is_rejected():
+    """Only ``T | None`` is a supported union; any other union must raise a clear syntax error."""
+    with pytest.raises(QuadrantsSyntaxError, match=r"T \| None"):
+
+        @qd.kernel
+        def k(x: int | float):
+            pass
+
+
+def test_multi_member_optional_union_is_rejected():
+    with pytest.raises(QuadrantsSyntaxError, match=r"T \| None"):
+
+        @qd.kernel
+        def k(x: qd.Tensor | int | None):
+            pass
+
+
+# ----------------------------------------------------------------------------
+# Runtime: qd.Tensor | None works end to end (both branches), just like the bare spelling.
+# ----------------------------------------------------------------------------
+
+
+@test_utils.test()
+def test_tensor_union_none_and_present_run():
+    out = qd.ndarray(qd.f32, shape=(4,))
+    bias = qd.ndarray(qd.f32, shape=(4,))
+    bias.from_numpy(np.full(4, 100.0, dtype=np.float32))
+
+    @qd.kernel
+    def add_bias(out: qd.types.NDArray[qd.f32, 1], bias: qd.Tensor | None):
+        for i in range(out.shape[0]):
+            if qd.static(bias is not None):
+                out[i] = qd.f32(i) + bias[i]
+            else:
+                out[i] = qd.f32(i)
+
+    add_bias(out, None)
+    np.testing.assert_array_equal(out.to_numpy(), np.arange(4, dtype=np.float32))
+
+    add_bias(out, qd.wrap(bias))
+    np.testing.assert_array_equal(out.to_numpy(), np.arange(4, dtype=np.float32) + 100.0)
+
+    # Present and absent branches specialize separately.
+    assert len(add_bias._primal.mapper.mapping) == 2
+
+
+@test_utils.test()
+def test_template_union_none_and_present_run():
+    out = qd.ndarray(qd.i32, shape=(1,))
+
+    @qd.kernel
+    def pick(out: qd.types.NDArray[qd.i32, 1], flag: qd.types.Template | None):
+        if qd.static(flag is not None):
+            out[0] = flag
+        else:
+            out[0] = -1
+
+    pick(out, None)
+    assert out.to_numpy()[0] == -1
+
+    pick(out, 7)
+    assert out.to_numpy()[0] == 7
+
+
+# ----------------------------------------------------------------------------
+# Runtime: qd.types.NDArray[...] | None. Present value works now; None is the W5 boundary.
+# ----------------------------------------------------------------------------
+
+
+@test_utils.test()
+def test_ndarray_union_present_value_runs():
+    a = qd.ndarray(qd.f32, shape=(4,))
+
+    @qd.kernel
+    def fill(x: qd.types.NDArray[qd.f32, 1] | None):
+        for i in range(x.shape[0]):
+            x[i] = qd.f32(i) * 10.0
+
+    fill(a)
+    np.testing.assert_array_equal(a.to_numpy(), np.array([0, 10, 20, 30], dtype=np.float32))
+
+
+@test_utils.test()
+def test_ndarray_union_none_not_yet_supported():
+    """W4/W5 boundary: an optional ndarray slot parses, but launching it with ``None`` still fails until W5 makes the
+    slot dual-nature. W5 will flip this test from raises to passes."""
+    a = qd.ndarray(qd.f32, shape=(4,))
+
+    @qd.kernel
+    def maybe_fill(x: qd.types.NDArray[qd.f32, 1] | None, out: qd.types.NDArray[qd.f32, 1]):
+        for i in range(out.shape[0]):
+            out[i] = qd.f32(i)
+
+    with pytest.raises(QuadrantsRuntimeTypeError):
+        maybe_fill(None, a)

--- a/tests/python/test_optional_annotation.py
+++ b/tests/python/test_optional_annotation.py
@@ -1,11 +1,4 @@
-"""Tests for the ``T | None`` optional kernel-argument spelling (design.md W4).
-
-W4 makes ``T | None`` parse uniformly for the three annotation families (``qd.Tensor``, ``qd.types.Template``,
-``qd.types.NDArray[...]``) and records the slot as optional on its ``ArgMetadata``. ``qd.Tensor`` and
-``qd.types.Template`` slots already accept ``None`` at runtime, so for those two the union spelling works end to end
-here. ``qd.types.NDArray[...] | None`` parses and still works when a value is present; making ``None`` actually launch
-against an ndarray slot is W5, and the boundary is pinned below.
-"""
+"""Tests for the ``T | None`` optional kernel-argument spelling."""
 
 import typing
 
@@ -18,10 +11,7 @@ from quadrants.types.ndarray_type import NdarrayType
 
 from tests import test_utils
 
-# ----------------------------------------------------------------------------
-# Parse + normalization: the union spelling is accepted and the slot is marked optional.
-# These run at @qd.kernel decoration time and need no qd.init().
-# ----------------------------------------------------------------------------
+# Parse + normalization (decoration-time, no qd.init()): the union spelling is accepted and marks the slot optional.
 
 
 def _arg0(kernel):
@@ -35,7 +25,7 @@ def test_tensor_union_parses_and_marks_optional():
 
     meta = _arg0(k)
     assert meta.optional is True
-    # None is stripped; the stored annotation is the bare qd.Tensor class, so downstream dispatch is unchanged.
+    # None is stripped: the stored annotation is the bare qd.Tensor, so downstream dispatch is unchanged.
     assert meta.annotation is qd.Tensor
 
 
@@ -56,15 +46,15 @@ def test_ndarray_union_parses_and_preserves_spec():
 
     meta = _arg0(k)
     assert meta.optional is True
-    # The dtype/ndim carried by the subscripted instance must survive the __or__ shim unwrap.
+    # The dtype/ndim on the subscripted instance must survive the __or__ unwrap.
     assert isinstance(meta.annotation, NdarrayType)
     assert meta.annotation.ndim == 1
     assert meta.annotation.dtype == qd.f32
 
 
 def test_optional_typing_form_parses_for_class_families():
-    """``typing.Optional[T]`` is equivalent to ``T | None`` for the two class-style families (design.md D1: the
-    ndarray family stays ``|``-only until issue 831, because ``Optional[instance]`` fails ``typing._type_check``)."""
+    """``typing.Optional[T]`` works for the class-style families; ndarray stays ``|``-only because ``NDArray[...]`` is
+    an instance and ``typing.Optional`` rejects instances."""
 
     @qd.kernel
     def kt(x: typing.Optional[qd.Tensor]):
@@ -107,9 +97,8 @@ def test_multi_member_optional_union_is_rejected():
 
 
 def test_optional_unsupported_family_is_rejected():
-    """`T | None` is only for qd.Tensor / qd.types.Template / qd.types.NDArray. A family with no absent-value path
-    (here a dataclass) must be rejected at registration, not silently recorded as optional and left to crash with an
-    internal AttributeError when `None` reaches the dataclass launch branch."""
+    """A family with no absent-value path (here a dataclass) must be rejected at registration, not silently recorded
+    as optional."""
     import dataclasses
 
     @dataclasses.dataclass
@@ -123,9 +112,7 @@ def test_optional_unsupported_family_is_rejected():
             pass
 
 
-# ----------------------------------------------------------------------------
 # Runtime: qd.Tensor | None works end to end (both branches), just like the bare spelling.
-# ----------------------------------------------------------------------------
 
 
 @test_utils.test()
@@ -170,9 +157,7 @@ def test_template_union_none_and_present_run():
     assert out.to_numpy()[0] == 7
 
 
-# ----------------------------------------------------------------------------
-# Runtime: qd.types.NDArray[...] | None. Present value works now; None is the W5 boundary.
-# ----------------------------------------------------------------------------
+# Runtime: qd.types.NDArray[...] | None. Present value works now; None is not supported yet.
 
 
 @test_utils.test()
@@ -190,8 +175,7 @@ def test_ndarray_union_present_value_runs():
 
 @test_utils.test()
 def test_ndarray_union_none_not_yet_supported():
-    """W4/W5 boundary: an optional ndarray slot parses, but launching it with ``None`` still fails until W5 makes the
-    slot dual-nature. W5 will flip this test from raises to passes."""
+    """An optional ndarray slot parses, but launching it with ``None`` is not supported yet."""
     a = qd.ndarray(qd.f32, shape=(4,))
 
     @qd.kernel


### PR DESCRIPTION
## Summary

W4 of the nullable-kernel-argument work (design in `perso_hugh/doc/nullable_tensor/design.md`): make the `T | None`
optional spelling **parse** uniformly across the three kernel-argument annotation families and record optionality on
the slot, as the prerequisite for dual-nature optional ndarray slots (W5).

- `_split_optional` normalizes `T | None` / `typing.Optional[T]` to `(inner, optional)` at the top of the annotation
  branch in `check_parameter_annotations`, then runs the **existing** per-family validation on `inner` unchanged. The
  present-value path is therefore byte-for-byte the old path. Only `T | None` unions are accepted; any other union
  raises a clear `QuadrantsSyntaxError`.
- `NdarrayType.__or__` returns an `_OptionalNdarray` marker so `qd.types.NDArray[...] | None` forms (it evaluates to
  an instance, not a type, so the interpreter can't build a `types.UnionType` from it the way it can for the
  class-style `qd.Tensor` / `qd.types.Template`). This is a deliberately-deletable shim, commented as superseded by
  #831.
- `ArgMetadata` carries a new `optional` flag (default `False`), consumed by W5. `annotation` is left as the bare
  `qd.Tensor` / `Template` / `NdarrayType`, so `template_slot_locations` and all downstream readers are untouched.

`qd.Tensor | None` and `qd.types.Template | None` already accept `None` at runtime (template slots), so those work
end to end via the union spelling now. `qd.types.NDArray[...] | None` parses and works when a value is present;
launching it with `None` still raises until W5 makes the slot dual-nature. That boundary is pinned by
`test_ndarray_union_none_not_yet_supported`, which W5 will flip from raises to passes.

## Test plan

New `tests/python/test_optional_annotation.py` (11 tests): all three families parse `T | None`; `Optional[T]` for the
two class families; optionality recorded on `ArgMetadata`; present-value ndarray unaffected; `Tensor`/`Template`
`None` run end to end; non-`None` and multi-member unions rejected; the W4/W5 ndarray-`None` boundary.

Verified on the cluster (full build against `main`), run via `tests/run_tests.py`:

- [x] `--arch x64`: 50 passed (`test_optional_annotation` + `test_tensor_annotation` + `test_compare`, the last
  carrying #859's `qd.static` presence tests) — no regressions
- [x] `--arch cuda`: 41 passed, 9 arch-skipped
- [x] black (`-l 120`) + ruff (pinned CI versions) + pylint (10/10) clean
- [ ] pyright — not runnable offline in the cluster container; deferred to CI

Made with [Cursor](https://cursor.com)