### PR TITLE
[Lang] Make kernel source capture resilient to transient linecache misses

### DIFF
--- a/python/quadrants/lang/_wrap_inspect.py
+++ b/python/quadrants/lang/_wrap_inspect.py
@@ -150,10 +150,9 @@ def _REPL_findsource(obj):
 
 
 def _direct_file_findsource(obj):
-    # Fallback for when linecache.getlines() transiently returns [] for a readable
-    # file (MemoryError -> linecache.clearcache(), or a transient os.stat/open
-    # failure), which would otherwise abort kernel compilation. Returns
-    # (lines, lineno) like inspect.findsource.
+    # Fallback for when linecache.getlines() transiently returns [] for a readable file (MemoryError ->
+    # linecache.clearcache(), or a transient os.stat/open failure), which would otherwise abort kernel compilation.
+    # Returns (lines, lineno) like inspect.findsource.
     code = getattr(obj, "__code__", None)
     if code is None:
         raise IOError(f"No __code__ to locate source for {obj}")

--- a/python/quadrants/lang/_wrap_inspect.py
+++ b/python/quadrants/lang/_wrap_inspect.py
@@ -19,6 +19,7 @@ import atexit
 import inspect
 import os
 import tempfile
+import tokenize
 from typing import Callable
 
 import dill
@@ -148,22 +149,56 @@ def _REPL_findsource(obj):
     return dill.source.findsource(obj)
 
 
+def _direct_file_findsource(obj):
+    """Locate an object's source by reading its file directly, bypassing linecache.
+
+    ``inspect.findsource`` relies on ``linecache.getlines``, which can transiently
+    return an empty list under memory or filesystem pressure: a ``MemoryError``
+    makes ``linecache.getlines`` call ``linecache.clearcache()`` and return ``[]``,
+    and a transient ``os.stat``/``open`` failure in ``linecache.updatecache`` has
+    the same effect. Because Quadrants materializes kernels by re-reading their
+    ``.py`` source at runtime, such a transient turns a perfectly readable file
+    into a fatal "cannot find source" error. Re-reading the file directly recovers
+    from that transient. Returns ``(lines, lineno)`` in the same shape as
+    ``inspect.findsource`` so it is a drop-in last-resort fallback.
+    """
+    code = getattr(obj, "__code__", None)
+    if code is None:
+        raise IOError(f"No __code__ to locate source for {obj}")
+    file = _builtin_getfile(obj)
+    with tokenize.open(file) as fp:  # honor the file's PEP 263 encoding cookie
+        lines = fp.readlines()
+    if not lines:
+        raise IOError(f"Empty or unreadable source file for {obj}: {file}")
+    return lines, code.co_firstlineno - 1
+
+
 def _custom_findsource(obj):
     try:
         return _Python_IPython_findsource(obj)
     except IOError:
-        try:
-            return _REPL_findsource(obj)
-        except:
-            try:
-                return _blender_findsource(obj)
-            except:
-                raise IOError(
-                    f"Cannot find source code for Object: {obj}, this \
-is possibly because of you are running Quadrants in an environment that Quadrants's own \
-inspect module cannot find the source. Please report an issue to help us fix: \
-https://github.com/Genesis-Embodied-AI/quadrants/issues"
-                )
+        pass
+    try:
+        return _REPL_findsource(obj)
+    except Exception:
+        pass
+    try:
+        return _blender_findsource(obj)
+    except Exception:
+        pass
+    # Last resort: bypass linecache and read the source file directly. This
+    # recovers from a transient empty ``linecache.getlines`` (see
+    # ``_direct_file_findsource``) instead of failing kernel compilation.
+    try:
+        return _direct_file_findsource(obj)
+    except Exception:
+        pass
+    raise IOError(
+        f"Cannot find source code for Object: {obj}, this is possibly because of "
+        "you are running Quadrants in an environment that Quadrants's own inspect "
+        "module cannot find the source. Please report an issue to help us fix: "
+        "https://github.com/Genesis-Embodied-AI/quadrants/issues"
+    )
 
 
 class _InspectContextManager:

--- a/python/quadrants/lang/_wrap_inspect.py
+++ b/python/quadrants/lang/_wrap_inspect.py
@@ -150,23 +150,15 @@ def _REPL_findsource(obj):
 
 
 def _direct_file_findsource(obj):
-    """Locate an object's source by reading its file directly, bypassing linecache.
-
-    ``inspect.findsource`` relies on ``linecache.getlines``, which can transiently
-    return an empty list under memory or filesystem pressure: a ``MemoryError``
-    makes ``linecache.getlines`` call ``linecache.clearcache()`` and return ``[]``,
-    and a transient ``os.stat``/``open`` failure in ``linecache.updatecache`` has
-    the same effect. Because Quadrants materializes kernels by re-reading their
-    ``.py`` source at runtime, such a transient turns a perfectly readable file
-    into a fatal "cannot find source" error. Re-reading the file directly recovers
-    from that transient. Returns ``(lines, lineno)`` in the same shape as
-    ``inspect.findsource`` so it is a drop-in last-resort fallback.
-    """
+    # Fallback for when linecache.getlines() transiently returns [] for a readable
+    # file (MemoryError -> linecache.clearcache(), or a transient os.stat/open
+    # failure), which would otherwise abort kernel compilation. Returns
+    # (lines, lineno) like inspect.findsource.
     code = getattr(obj, "__code__", None)
     if code is None:
         raise IOError(f"No __code__ to locate source for {obj}")
     file = _builtin_getfile(obj)
-    with tokenize.open(file) as fp:  # honor the file's PEP 263 encoding cookie
+    with tokenize.open(file) as fp:
         lines = fp.readlines()
     if not lines:
         raise IOError(f"Empty or unreadable source file for {obj}: {file}")
@@ -186,9 +178,7 @@ def _custom_findsource(obj):
         return _blender_findsource(obj)
     except Exception:
         pass
-    # Last resort: bypass linecache and read the source file directly. This
-    # recovers from a transient empty ``linecache.getlines`` (see
-    # ``_direct_file_findsource``) instead of failing kernel compilation.
+    # Last resort: re-read the file directly, recovering from a transient linecache miss.
     try:
         return _direct_file_findsource(obj)
     except Exception:

--- a/tests/python/test_wrap_inspect_source_capture.py
+++ b/tests/python/test_wrap_inspect_source_capture.py
@@ -1,0 +1,59 @@
+"""Regression test: kernel source capture must survive a transient linecache miss.
+
+Reproduces the failure where stdlib ``linecache.getlines`` transiently returns an
+empty list for ``quadrants/_kernels.py``. This was observed under heavy concurrent
+load (dozens of xdist workers plus torch/CUDA and other jobs on the node): a
+``MemoryError`` makes ``linecache.getlines`` call ``linecache.clearcache()`` and
+return ``[]``, and transient ``os.stat``/``open`` failures in
+``linecache.updatecache`` have the same effect.
+
+Because Quadrants materializes kernels by re-reading their ``.py`` source at
+runtime (``inspect.getsourcelines`` -> ``linecache``), and every ``_wrap_inspect``
+fallback (stdlib, dill, bpy) is linecache/source based, a single transient empty
+read turned a readable file into a fatal
+``OSError: Cannot find source code for Object: <function ext_arr_to_ndarray ...>``
+(``_wrap_inspect.py``). The direct-file fallback added in ``_custom_findsource``
+recovers from that transient.
+
+CPU-only; no device initialization required.
+"""
+
+import linecache
+
+from quadrants._kernels import ext_arr_to_ndarray
+from quadrants.lang import _wrap_inspect
+
+
+def _kernel_fn():
+    # ``@kernel`` wraps the function; the raw function is exposed as ``.fn``.
+    return getattr(ext_arr_to_ndarray, "fn", ext_arr_to_ndarray)
+
+
+def test_source_capture_survives_transient_linecache_miss(monkeypatch):
+    fn = _kernel_fn()
+
+    real_getlines = linecache.getlines
+
+    def flaky_getlines(filename, module_globals=None):
+        # Simulate the transient empty read for the kernel's own source file.
+        if filename.endswith("quadrants/_kernels.py"):
+            return []
+        return real_getlines(filename, module_globals)
+
+    monkeypatch.setattr(linecache, "getlines", flaky_getlines)
+
+    # Before the fix this raised OSError; the direct-file fallback must recover.
+    info, src = _wrap_inspect.get_source_info_and_src(fn)
+
+    assert info.function_name == "ext_arr_to_ndarray"
+    assert "def ext_arr_to_ndarray" in "".join(src)
+
+
+def test_direct_file_findsource_matches_stdlib():
+    # The direct-read fallback must return the same source as the normal path
+    # when linecache is healthy.
+    fn = _kernel_fn()
+    _info, src_normal = _wrap_inspect.get_source_info_and_src(fn)
+    lines, lineno = _wrap_inspect._direct_file_findsource(fn)
+    assert lines[lineno].lstrip().startswith(("def ext_arr_to_ndarray", "@"))
+    assert "".join(src_normal).strip() in "".join(lines)

--- a/tests/python/test_wrap_inspect_source_capture.py
+++ b/tests/python/test_wrap_inspect_source_capture.py
@@ -1,21 +1,7 @@
-"""Regression test: kernel source capture must survive a transient linecache miss.
+"""Kernel source capture must survive a transient empty linecache.getlines().
 
-Reproduces the failure where stdlib ``linecache.getlines`` transiently returns an
-empty list for ``quadrants/_kernels.py``. This was observed under heavy concurrent
-load (dozens of xdist workers plus torch/CUDA and other jobs on the node): a
-``MemoryError`` makes ``linecache.getlines`` call ``linecache.clearcache()`` and
-return ``[]``, and transient ``os.stat``/``open`` failures in
-``linecache.updatecache`` have the same effect.
-
-Because Quadrants materializes kernels by re-reading their ``.py`` source at
-runtime (``inspect.getsourcelines`` -> ``linecache``), and every ``_wrap_inspect``
-fallback (stdlib, dill, bpy) is linecache/source based, a single transient empty
-read turned a readable file into a fatal
-``OSError: Cannot find source code for Object: <function ext_arr_to_ndarray ...>``
-(``_wrap_inspect.py``). The direct-file fallback added in ``_custom_findsource``
-recovers from that transient.
-
-CPU-only; no device initialization required.
+Guards against the OSError seen when linecache.getlines() transiently returns []
+for quadrants/_kernels.py under load, which aborted kernel compilation. CPU-only.
 """
 
 import linecache
@@ -25,33 +11,26 @@ from quadrants.lang import _wrap_inspect
 
 
 def _kernel_fn():
-    # ``@kernel`` wraps the function; the raw function is exposed as ``.fn``.
     return getattr(ext_arr_to_ndarray, "fn", ext_arr_to_ndarray)
 
 
 def test_source_capture_survives_transient_linecache_miss(monkeypatch):
     fn = _kernel_fn()
-
     real_getlines = linecache.getlines
 
     def flaky_getlines(filename, module_globals=None):
-        # Simulate the transient empty read for the kernel's own source file.
         if filename.endswith("quadrants/_kernels.py"):
             return []
         return real_getlines(filename, module_globals)
 
     monkeypatch.setattr(linecache, "getlines", flaky_getlines)
 
-    # Before the fix this raised OSError; the direct-file fallback must recover.
     info, src = _wrap_inspect.get_source_info_and_src(fn)
-
     assert info.function_name == "ext_arr_to_ndarray"
     assert "def ext_arr_to_ndarray" in "".join(src)
 
 
 def test_direct_file_findsource_matches_stdlib():
-    # The direct-read fallback must return the same source as the normal path
-    # when linecache is healthy.
     fn = _kernel_fn()
     _info, src_normal = _wrap_inspect.get_source_info_and_src(fn)
     lines, lineno = _wrap_inspect._direct_file_findsource(fn)

--- a/tests/python/test_wrap_inspect_source_capture.py
+++ b/tests/python/test_wrap_inspect_source_capture.py
@@ -1,7 +1,7 @@
 """Kernel source capture must survive a transient empty linecache.getlines().
 
-Guards against the OSError seen when linecache.getlines() transiently returns []
-for quadrants/_kernels.py under load, which aborted kernel compilation. CPU-only.
+Guards against the OSError seen when linecache.getlines() transiently returns [] for quadrants/_kernels.py under load,
+which aborted kernel compilation. CPU-only.
 """
 
 import linecache


### PR DESCRIPTION
## Summary

- Kernel materialization re-reads each kernel's `.py` source at runtime via `inspect.getsourcelines` -> stdlib `linecache.getlines`. Under memory or filesystem pressure `getlines` can transiently return an empty list (a `MemoryError` makes it call `linecache.clearcache()` and return `[]`; a transient `os.stat`/`open` failure in `updatecache` has the same effect). Because every `_wrap_inspect` fallback (stdlib, dill, bpy) is linecache/source based, one such transient turned a perfectly readable file into a fatal `OSError: Cannot find source code for Object: <function ext_arr_to_ndarray ...>` (`_wrap_inspect.py:161`), aborting compilation.
- Adds a last-resort `_direct_file_findsource` that bypasses linecache and re-reads the source file directly (honoring the PEP 263 encoding cookie), wired in as the final fallback in `_custom_findsource`. Also flattens the fallback chain; the original error message is preserved verbatim for the genuinely-unrecoverable case.
- Adds a CPU-only regression test that injects the transient empty `getlines` and asserts source capture still succeeds.

## Root cause (why it was flaky / environment-gated)

This surfaced as intermittent failures of Genesis IPC tests (e.g. `test_contact_pair_friction_resistance`) under heavy concurrent test load (dozens of xdist workers + torch/CUDA + other jobs on the node). The failing kernel `ext_arr_to_ndarray` is materialized by an explicit `from_numpy` deep in the rigid constraint solver, on the first `sim.step()` during `scene.build()`.

Instrumentation of `get_source_info_and_src` showed the failing kernel is source-captured an identical number of times on the affected and unaffected commits, and injecting a single empty `getlines` at that capture reproduces the exact error on both. So this is a preexisting fragility in quadrants' runtime source-inspection path (not a specific-branch regression), and it can affect any kernel. The `Lock ... failed` offline-cache warnings seen alongside it are a symptom of the same contended environment, not the cause.

## Test plan / evidence

Red/green against the `main` wheel (`3d97d7c32`), CPU-only (no device init):

- Unpatched: `2 failed` -- `OSError: Cannot find source code for ... ext_arr_to_ndarray` at `_wrap_inspect.py:161`.
- Patched:   `2 passed`.

- [ ] CI green on the full suite.

Made with [Cursor](https://cursor.com)