### PR TITLE
[Misc] Make qd.init arch optional and stop QD_ARCH overriding arch arg

### DIFF
--- a/python/quadrants/lang/misc.py
+++ b/python/quadrants/lang/misc.py
@@ -490,9 +490,7 @@ def init(
         runtime.print_non_pure = print_non_pure
         _logging.set_logging_level(spec_cfg.log_level.lower())
 
-    # select arch (backend). The qd.init argument takes priority over the QD_ARCH env var (mirroring default_fp/ip);
-    # the env var is only consulted when no arch argument was passed. When neither is set, adaptive_arch_select falls
-    # back to cpu, so arch remains optional.
+    # select arch (backend):
     env_arch = os.environ.get("QD_ARCH")
     if env_arch is not None:
         if arch is not None:

--- a/python/quadrants/lang/misc.py
+++ b/python/quadrants/lang/misc.py
@@ -490,11 +490,16 @@ def init(
         runtime.print_non_pure = print_non_pure
         _logging.set_logging_level(spec_cfg.log_level.lower())
 
-    # select arch (backend):
+    # select arch (backend). The qd.init argument takes priority over the QD_ARCH env var (mirroring default_fp/ip);
+    # the env var is only consulted when no arch argument was passed. When neither is set, adaptive_arch_select falls
+    # back to cpu, so arch remains optional.
     env_arch = os.environ.get("QD_ARCH")
     if env_arch is not None:
-        _logging.info(f"Following QD_ARCH setting up for arch={env_arch}")
-        arch = _qd_core.arch_from_name(env_arch)
+        if arch is not None:
+            _qd_core.warn(f'Environment variable QD_ARCH={env_arch} overridden by qd.init argument "arch"')
+        else:
+            _logging.info(f"Following QD_ARCH setting up for arch={env_arch}")
+            arch = _qd_core.arch_from_name(env_arch)
     cfg.arch = adaptive_arch_select(arch, enable_fallback)
     print(f"[Quadrants] Starting on arch={_qd_core.arch_name(cfg.arch)}")
 

--- a/quadrants/python/export_lang.cpp
+++ b/quadrants/python/export_lang.cpp
@@ -167,7 +167,8 @@ void export_lang(nb::module_ &m) {
       .def(nb::init<>())
       .def_rw("arch", &CompileConfig::arch,
               "Target backend the kernels run on (e.g. qd.cpu, qd.cuda, qd.vulkan, qd.metal). Defaults to qd.cpu when "
-              "arch is not specified.")
+              "arch is not specified. Also settable via the QD_ARCH environment variable; if both are set, this "
+              "argument takes precedence and a warning is logged.")
       .def_rw("opt_level", &CompileConfig::opt_level,
               "Quadrants IR optimization level. At 0, IR-level optimizations such as common-subexpression elimination "
               "are disabled; any value above 0 enables them. This is not an LLVM -O level.")

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -146,6 +146,22 @@ def test_init_arch(arch):
         assert qd.lang.impl.current_cfg().arch == arch
 
 
+def test_init_arch_optional_defaults_to_cpu():
+    # arch is optional: with no arch argument and no QD_ARCH env var, qd.init falls back to cpu.
+    with patch_os_environ_helper({}, excludes=["QD_ARCH"]):
+        qd.init()
+        assert qd.lang.impl.current_cfg().arch == qd.cpu
+
+
+@pytest.mark.parametrize("arch", test_utils.expected_archs())
+def test_init_arch_arg_overrides_env(arch):
+    # The qd.init arch argument takes priority over the QD_ARCH env var. QD_ARCH is set to an unsupported backend here;
+    # if it were still overriding the argument, adaptive_arch_select would fall back to cpu and the assert would fail.
+    with patch_os_environ_helper({"QD_ARCH": "opencl"}, excludes=["QD_ARCH"]):
+        qd.init(arch=arch)
+        assert qd.lang.impl.current_cfg().arch == arch
+
+
 @test_utils.test(arch=qd.cpu)
 def test_init_bad_arg():
     with pytest.raises(KeyError):

--- a/tests/python/test_runtime.py
+++ b/tests/python/test_runtime.py
@@ -147,7 +147,6 @@ def test_init_arch(arch):
 
 
 def test_init_arch_optional_defaults_to_cpu():
-    # arch is optional: with no arch argument and no QD_ARCH env var, qd.init falls back to cpu.
     with patch_os_environ_helper({}, excludes=["QD_ARCH"]):
         qd.init()
         assert qd.lang.impl.current_cfg().arch == qd.cpu
@@ -155,8 +154,8 @@ def test_init_arch_optional_defaults_to_cpu():
 
 @pytest.mark.parametrize("arch", test_utils.expected_archs())
 def test_init_arch_arg_overrides_env(arch):
-    # The qd.init arch argument takes priority over the QD_ARCH env var. QD_ARCH is set to an unsupported backend here;
-    # if it were still overriding the argument, adaptive_arch_select would fall back to cpu and the assert would fail.
+    # QD_ARCH is an unsupported backend, so if it still overrode the argument, adaptive_arch_select would fall back to
+    # cpu and the assert would fail.
     with patch_os_environ_helper({"QD_ARCH": "opencl"}, excludes=["QD_ARCH"]):
         qd.init(arch=arch)
         assert qd.lang.impl.current_cfg().arch == arch


### PR DESCRIPTION
## Summary

- `qd.init`'s `arch` argument now takes priority over the `QD_ARCH` env var, mirroring how `default_fp` / `default_ip` already behave. Previously `QD_ARCH` unconditionally overrode whatever `arch` was passed to `qd.init`.
- `QD_ARCH` is only consulted when no `arch` argument is passed; when both are set, a warning is emitted and the argument wins.
- `arch` stays optional: with neither an argument nor `QD_ARCH`, `adaptive_arch_select` falls back to `cpu`.

This also sidesteps a gotcha where `arch_from_name` only accepts the names in `archs.inc.h` (`x64/arm64/js/python/cuda/metal/opencl/amdgpu/vulkan`), so an explicit `arch=` argument is no longer discarded in favor of parsing the env var.

## Test plan

- Added `test_init_arch_optional_defaults_to_cpu` and `test_init_arch_arg_overrides_env` to `tests/python/test_runtime.py`.
- Built quadrants (CUDA + x64) on an rtx-mid node and ran the arch tests: 5 passed, 4 skipped (unavailable backends). The `test_init_arch_arg_overrides_env[Arch.cuda]` case confirms `qd.init(arch=cuda)` wins over `QD_ARCH=opencl` (would fail under the old override behavior).
- Full `test_runtime.py`: 48 passed, 0 failed.

Made with [Cursor](https://cursor.com)