### PR TITLE
[Lang] W6 qd.static presence check names the optional ndarray family

### DIFF
--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -978,8 +978,8 @@ class ASTTransformer(Builder):
                 ):
                     raise QuadrantsSyntaxError(
                         f'Operator "{name}" inside `qd.static` compares a direct kernel argument against `None`. '
-                        "The argument must be annotated `qd.types.Template`, `qd.Tensor`, "
-                        "or optional `qd.types.NDArray[...] | None`."
+                        "The argument must be annotated `qd.Tensor | None`, `qd.types.Template | None`, "
+                        "or `qd.types.NDArray[...] | None`."
                     )
                 if template_side == "left":
                     l = ctx.template_vars[template_node.id]

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -977,7 +977,8 @@ class ASTTransformer(Builder):
                     or template_node.id not in ctx.template_vars
                 ):
                     raise QuadrantsSyntaxError(
-                        f'Operator "{name}" inside `qd.static` requires a direct `qd.template()` or `qd.Tensor` kernel argument and `None`.'
+                        f'Operator "{name}" inside `qd.static` requires a direct kernel argument annotated '
+                        f'`qd.types.Template`, `qd.Tensor`, or optional `qd.types.NDArray[...] | None`, and `None`.'
                     )
                 if template_side == "left":
                     l = ctx.template_vars[template_node.id]

--- a/python/quadrants/lang/ast/ast_transformer.py
+++ b/python/quadrants/lang/ast/ast_transformer.py
@@ -977,8 +977,9 @@ class ASTTransformer(Builder):
                     or template_node.id not in ctx.template_vars
                 ):
                     raise QuadrantsSyntaxError(
-                        f'Operator "{name}" inside `qd.static` requires a direct kernel argument annotated '
-                        f'`qd.types.Template`, `qd.Tensor`, or optional `qd.types.NDArray[...] | None`, and `None`.'
+                        f'Operator "{name}" inside `qd.static` compares a direct kernel argument against `None`. '
+                        "The argument must be annotated `qd.types.Template`, `qd.Tensor`, "
+                        "or optional `qd.types.NDArray[...] | None`."
                     )
                 if template_side == "left":
                     l = ctx.template_vars[template_node.id]

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -182,7 +182,7 @@ def test_static_is_rejects_runtime_operands():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
+        match=r'Operator "is" inside `qd.static` compares a direct kernel argument against `None`',
     ):
         scalar(0)
 
@@ -194,7 +194,7 @@ def test_static_is_rejects_runtime_operands():
     value = qd.ndarray(qd.i32, shape=(1,))
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is not" inside `qd.static` requires a direct kernel argument annotated',
+        match=r'Operator "is not" inside `qd.static` compares a direct kernel argument against `None`',
     ):
         array(value)
 
@@ -204,7 +204,7 @@ def test_static_is_rejects_runtime_operands():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
+        match=r'Operator "is" inside `qd.static` compares a direct kernel argument against `None`',
     ):
         reserved_name(None)
 
@@ -217,7 +217,7 @@ def test_static_is_rejects_runtime_operands():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
+        match=r'Operator "is" inside `qd.static` compares a direct kernel argument against `None`',
     ):
         shadowed_template(7)
 
@@ -256,7 +256,7 @@ def test_static_is_rejects_non_none_identity():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
+        match=r'Operator "is" inside `qd.static` compares a direct kernel argument against `None`',
     ):
         same(qd.i32)
 

--- a/tests/python/test_compare.py
+++ b/tests/python/test_compare.py
@@ -182,10 +182,11 @@ def test_static_is_rejects_runtime_operands():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
     ):
         scalar(0)
 
+    # A non-optional ndarray still rejects; presence checks need the opt-in qd.types.NDArray[...] | None form.
     @qd.kernel
     def array(value: qd.types.ndarray()) -> qd.i32:
         return 1 if qd.static(value is not None) else 0
@@ -193,7 +194,7 @@ def test_static_is_rejects_runtime_operands():
     value = qd.ndarray(qd.i32, shape=(1,))
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is not" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+        match=r'Operator "is not" inside `qd.static` requires a direct kernel argument annotated',
     ):
         array(value)
 
@@ -203,7 +204,7 @@ def test_static_is_rejects_runtime_operands():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
     ):
         reserved_name(None)
 
@@ -216,7 +217,7 @@ def test_static_is_rejects_runtime_operands():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
     ):
         shadowed_template(7)
 
@@ -236,6 +237,18 @@ def test_static_is_accepts_tensor_presence():
 
 
 @test_utils.test()
+def test_static_is_accepts_optional_ndarray_presence():
+    @qd.kernel
+    def present(value: qd.types.NDArray[qd.i32, 1] | None) -> qd.i32:
+        return 1 if qd.static(value is not None) else 0
+
+    array = qd.ndarray(qd.i32, shape=(1,))
+
+    assert present(None) == 0
+    assert present(array) == 1
+
+
+@test_utils.test()
 def test_static_is_rejects_non_none_identity():
     @qd.kernel
     def same(value: qd.template()) -> qd.i32:
@@ -243,7 +256,7 @@ def test_static_is_rejects_non_none_identity():
 
     with pytest.raises(
         qd.QuadrantsSyntaxError,
-        match=r'Operator "is" inside `qd.static` requires a direct `qd.template\(\)` or `qd.Tensor` kernel argument and `None`',
+        match=r'Operator "is" inside `qd.static` requires a direct kernel argument annotated',
     ):
         same(qd.i32)
 


### PR DESCRIPTION
## Summary

Final item (W6) of the nullable-kernel-argument series. W5 made optional `qd.types.NDArray[...] | None` slots dual-nature, and the `qd.static` presence-check guard already admits them because its allowlist keys off `template_slot_locations` (which W5 populates) rather than hardcoding annotation families. So the guard logic needs no change - the only stale surface is the error string.

- Reword the `qd.static` `is` / `is not None` error to canonical spellings and name the newly-eligible optional ndarray family: `qd.types.Template`, `qd.Tensor`, or optional `qd.types.NDArray[...] | None`.
- Tests: retarget the four `match=` regexes in `test_static_is_rejects_runtime_operands`; keep the non-optional ndarray reject (a bare ndarray must opt in with `| None`); add `test_static_is_accepts_optional_ndarray_presence` for the optional form.
- No doc changes: `static.md` / `tensor.md` were already brought up to date during W4/W5.

Note on the design doc's D3: it said "the array case flips from reject to accept". Under the opt-in decision (D2) a *non-optional* ndarray still correctly rejects, so W6 keeps that reject (new wording) and adds a separate optional-ndarray accept case.

## Test plan

- [ ] `test_compare` + `test_optional_annotation` pass on x64 and cuda
- [ ] CI green

Made with [Cursor](https://cursor.com)